### PR TITLE
Ensure database writes commit and surface row counts

### DIFF
--- a/src/web/db/db_class.py
+++ b/src/web/db/db_class.py
@@ -34,7 +34,8 @@ class Database:
                     result = cursor.fetchall()
                     return result
                 else:
-                    return {}
+                    self.connection.commit()
+                    return cursor.rowcount
 
         except pymysql.MySQLError as e:
             print(f"SQL error: {e}<br>{sql_query}")

--- a/src/web/db/svg_db.py
+++ b/src/web/db/svg_db.py
@@ -36,7 +36,8 @@ class Database:
                 result = cursor.fetchall()
                 return result
             else:
-                return {}
+                self.connection.commit()
+                return cursor.rowcount
 
     def fetch_query(self, sql_query, params=None):
         with self.connection.cursor() as cursor:

--- a/tests/test_db_commit.py
+++ b/tests/test_db_commit.py
@@ -1,0 +1,79 @@
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    import pymysql  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed when pymysql is unavailable
+    pymysql = types.ModuleType("pymysql")
+    pymysql.MySQLError = Exception
+    pymysql.cursors = types.SimpleNamespace(DictCursor=object)
+    sys.modules["pymysql"] = pymysql
+else:  # pragma: no cover - executed when pymysql is available
+    if not hasattr(pymysql, "MySQLError"):
+        pymysql.MySQLError = Exception
+    if not hasattr(pymysql, "cursors"):
+        pymysql.cursors = types.SimpleNamespace(DictCursor=object)
+    elif not hasattr(pymysql.cursors, "DictCursor"):
+        pymysql.cursors.DictCursor = object
+
+
+@pytest.fixture
+def db_factory(monkeypatch):
+    def _factory(module_name: str):
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        cursor.__exit__.return_value = False
+        cursor.fetchall.return_value = []
+        cursor.rowcount = 0
+
+        connection = MagicMock()
+        connection.cursor.return_value = cursor
+        connection.commit = MagicMock()
+
+        monkeypatch.setattr(pymysql, "connect", MagicMock(return_value=connection))
+
+        module = importlib.import_module(module_name)
+
+        db = module.Database({
+            "host": "localhost",
+            "user": "user",
+            "dbname": "database",
+            "password": "password",
+        })
+
+        return db, connection, cursor
+
+    return _factory
+
+
+@pytest.mark.parametrize("module_name", [
+    "src.web.db.db_class",
+    "src.web.db.svg_db",
+])
+def test_execute_query_commits_for_writes(db_factory, module_name):
+    db, connection, cursor = db_factory(module_name)
+    cursor.rowcount = 3
+
+    result = db.execute_query("INSERT INTO example VALUES (1)")
+
+    connection.commit.assert_called_once()
+    assert result == 3
+
+
+@pytest.mark.parametrize("module_name", [
+    "src.web.db.db_class",
+    "src.web.db.svg_db",
+])
+def test_execute_query_skips_commit_for_select(db_factory, module_name):
+    db, connection, cursor = db_factory(module_name)
+    rows = [{"id": 1}]
+    cursor.fetchall.return_value = rows
+
+    result = db.execute_query("SELECT * FROM example")
+
+    connection.commit.assert_not_called()
+    assert result == rows


### PR DESCRIPTION
## Summary
- trigger a commit whenever non-SELECT statements execute through the database helpers
- return the cursor rowcount for write operations so callers can inspect affected rows
- add regression coverage that mocks a PyMySQL connection to assert commits for writes while skipping reads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f484052750832292f7d11dc4d3f897