### PR TITLE
Add shared layout and all tasks view

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}SVG Translate Bot{% endblock %}</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    {% block extra_css %}{% endblock %}
+</head>
+
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="{{ url_for('index') }}">SVG Translate</a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav"
+                aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.endpoint == 'index' %}active{% endif %}"
+                            {% if request.endpoint == 'index' %}aria-current="page"{% endif %}
+                            href="{{ url_for('index') }}">Home</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link {% if request.endpoint == 'tasks' %}active{% endif %}"
+                            {% if request.endpoint == 'tasks' %}aria-current="page"{% endif %}
+                            href="{{ url_for('tasks') }}">All Tasks</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container py-4">
+        {% block content %}{% endblock %}
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    {% block extra_js %}{% endblock %}
+</body>
+
+</html>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1,11 +1,8 @@
-<!doctype html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>SVG Translate Bot</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+{% block title %}SVG Translate Bot{% endblock %}
+
+{% block extra_css %}
     <style>
         a {
             text-decoration: none;
@@ -13,21 +10,6 @@
 
         .list-group-item.running {
             border-left: 4px solid var(--bs-primary);
-            /* animation: pulse 1.5s infinite; */
-        }
-
-        @keyframes pulse {
-            0% {
-                opacity: 1;
-            }
-
-            50% {
-                opacity: 0.5;
-            }
-
-            100% {
-                opacity: 1;
-            }
         }
 
         @media (max-width: 576px) {
@@ -40,52 +22,51 @@
             }
         }
     </style>
-</head>
+{% endblock %}
 
-<body>
-    <div class="container py-4">
-        <h1 class="mb-4">SVG Translate Bot</h1>
+{% block content %}
+    <h1 class="mb-4">SVG Translate Bot</h1>
 
-        {% if error_message %}
+    {% if error_message %}
         <div class="alert alert-info" role="alert">{{ error_message }}</div>
-        {% endif %}
+    {% endif %}
 
-        <form method="post" class="row gy-2 gx-3 align-items-center mb-4">
-            <div class="col-12 col-md-6">
-                <label for="title" class="form-label">Template Title</label>
-                <input type="text" class="form-control" id="title" name="title"
-                    value="{{ form.title if form and form.title else 'Template:OWID/death rate from obesity'}}"
-                    required>
+    <form method="post" class="row gy-2 gx-3 align-items-center mb-4">
+        <div class="col-12 col-md-6">
+            <label for="title" class="form-label">Template Title</label>
+            <input type="text" class="form-control" id="title" name="title"
+                value="{{ form.title if form and form.title else 'Template:OWID/death rate from obesity'}}"
+                required>
+        </div>
+        <div class="col-6 col-md-3">
+            <label for="titles_limit" class="form-label">Titles Limit</label>
+            <input type="number" class="form-control" id="titles_limit" name="titles_limit" min="1"
+                value="{{ form.titles_limit if form and form.titles_limit else 1000 }}">
+        </div>
+        <div class="col-12 col-md-3 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary w-100">Start</button>
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="form-check form-switch mt-2">
+                <input class="form-check-input" type="checkbox" value="z" id="overwrite" name="overwrite"
+                    {{ 'checked' if not form or form.overwrite == "z" else '' }}>
+                <label class="form-check-label" for="overwrite">
+                    Overwrite Existing translations
+                </label>
             </div>
-            <div class="col-6 col-md-3">
-                <label for="titles_limit" class="form-label">Titles Limit</label>
-                <input type="number" class="form-control" id="titles_limit" name="titles_limit" min="1"
-                    value="{{ form.titles_limit if form and form.titles_limit else 1000 }}">
+        </div>
+        <div class="col-6 col-md-3">
+            <div class="form-check form-switch mt-2">
+                <input class="form-check-input" type="checkbox" value="1" id="upload" name="upload"
+                    {{ 'checked' if form and form.upload else '' }}>
+                <label class="form-check-label" for="upload">
+                    Upload New translations
+                </label>
             </div>
-            <div class="col-12 col-md-3 d-flex align-items-end">
-                <button type="submit" class="btn btn-primary w-100">Start</button>
-            </div>
-            <div class="col-6 col-md-3">
-                <div class="form-check form-switch mt-2">
-                    <input class="form-check-input" type="checkbox" value="z" id="overwrite" name="overwrite"
-                        {{ 'checked' if not form or form.overwrite == "z" else '' }}>
-                    <label class="form-check-label" for="overwrite">
-                        Overwrite Existing translations
-                    </label>
-                </div>
-            </div>
-            <div class="col-6 col-md-3">
-                <div class="form-check form-switch mt-2">
-                    <input class="form-check-input" type="checkbox" value="1" id="upload" name="upload"
-                        {{ 'checked' if form and form.upload else '' }}>
-                    <label class="form-check-label" for="upload">
-                        Upload New translations
-                    </label>
-                </div>
-            </div>
-        </form>
+        </div>
+    </form>
 
-        {% if task_id %}
+    {% if task_id %}
         <div id="progress-section" data-task-id="{{ task_id }}">
             <h2 class="h5">
                 Task Status <span id="task_status">
@@ -107,9 +88,10 @@
             <div class="mt-4" id="results">
             </div>
         </div>
-        {% endif %}
-    </div>
+    {% endif %}
+{% endblock %}
 
+{% block extra_js %}
     <script>
         (function () {
             const section = document.getElementById('progress-section');
@@ -168,7 +150,6 @@
                     const res = await fetch(`/status/${taskId}`, { cache: "no-store" });
                     const taskData = await res.json();
                     if (!res.ok) {
-                        // Stop polling on completion or error
                         if (taskData?.error === 'not-found') {
                             document.getElementById("task_status").innerText = " (Not Found)";
                             document.getElementById("alert_div").innerHTML = `
@@ -181,24 +162,15 @@
                         return;
                     }
 
-                    // Update stages
                     const stagesContainerNew = document.getElementById('stagesnew');
-                    // ---
                     if (taskData.data && taskData.data.stages) {
-                        // ---
                         let stages_obj = taskData.data.stages;
-                        // {"initialize":{"number": 1, "message":"Starting workflow","status":"Running"}, ... }
-                        // ---
-                        // sort stages_obj by number
                         stages_obj = Object.entries(stages_obj).sort((a, b) => a[1].number - b[1].number);
-                        // ---
                         document.getElementById("global-progress").style.width = `${overall_progress(stages_obj)}%`;
-                        // ---
                         stagesContainerNew.innerHTML = stages_obj.map(([name, st]) => stages_html_new(st, name)).join('');
                     }
 
-                    // Update results
-                    const results = document.getElementById('results_x');
+                    const results = document.getElementById('results');
                     if (taskData && taskData.results && results) {
                         const r = taskData.results;
                         results.innerHTML = result_html(r);
@@ -208,7 +180,6 @@
                         document.getElementById("task_status").innerText = ` (${taskData.status})`;
                     }
 
-                    // Stop polling on completion or error
                     if (['Completed', 'error', 'Failed'].includes(taskData.status)) {
                         clearInterval(timer);
                     }
@@ -222,6 +193,4 @@
             refresh();
         })();
     </script>
-</body>
-
-</html>
+{% endblock %}

--- a/src/web/templates/index2.html
+++ b/src/web/templates/index2.html
@@ -1,38 +1,34 @@
-<!doctype html>
-<html lang="en">
+{% extends "base.html" %}
 
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>SVG Translate Bot</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+{% block title %}SVG Translate Bot{% endblock %}
+
+{% block extra_css %}
     <style>
         a {
             text-decoration: none;
         }
     </style>
-</head>
+{% endblock %}
 
-<body>
-    <div class="container py-4">
-        <h1 class="mb-4">SVG Translate Bot</h1>
+{% block content %}
+    <h1 class="mb-4">SVG Translate Bot</h1>
 
-        {% if error_message %}
+    {% if error_message %}
         <div class="alert alert-info" role="alert">{{ error_message }}</div>
-        {% endif %}
+    {% endif %}
 
-        <form method="post" class="row gy-2 gx-3 align-items-center mb-4">
-            <div class="col-sm-8">
-                <label for="title" class="form-label">Template Title</label>
-                <input type="text" class="form-control" id="title" name="title"
-                    value="Template:OWID/death rate from obesity" required>
-            </div>
-            <div class="col-sm-4 d-flex align-items-end">
-                <button type="submit" class="btn btn-primary w-100">Start</button>
-            </div>
-        </form>
+    <form method="post" class="row gy-2 gx-3 align-items-center mb-4">
+        <div class="col-sm-8">
+            <label for="title" class="form-label">Template Title</label>
+            <input type="text" class="form-control" id="title" name="title"
+                value="Template:OWID/death rate from obesity" required>
+        </div>
+        <div class="col-sm-4 d-flex align-items-end">
+            <button type="submit" class="btn btn-primary w-100">Start</button>
+        </div>
+    </form>
 
-        {% if task_id %}
+    {% if task_id %}
         <div id="progress-section" data-task-id="{{ task_id }}">
             <h2 class="h5">
                 Task Status <span id="task_status">
@@ -47,46 +43,47 @@
             </div>
             <div id="stages" class="row g-3">
                 {% if task and task.data and task.data.stages %}
-                {% for name, st in task.data.stages.items() %}
-                <div class="col-12 col-md-6">
-                    <div class="card">
-                        <div class="card-body">
-                            <h5 class="card-title">{{ name }}</h5>
-                            <p class="card-text">{{ st.message }}</p>
-                            <span class="badge text-bg-secondary">{{ st.status }}</span>
+                    {% for name, st in task.data.stages.items() %}
+                        <div class="col-12 col-md-6">
+                            <div class="card">
+                                <div class="card-body">
+                                    <h5 class="card-title">{{ name }}</h5>
+                                    <p class="card-text">{{ st.message }}</p>
+                                    <span class="badge text-bg-secondary">{{ st.status }}</span>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-                {% endfor %}
+                    {% endfor %}
                 {% else %}
-                <div class="col-12" id="alert_div">
-                    {% if task.error and task.error == 'not-found' %}
-                    <div class="alert alert-danger" role="alert">
-                        Task not found.
+                    <div class="col-12" id="alert_div">
+                        {% if task.error and task.error == 'not-found' %}
+                            <div class="alert alert-danger" role="alert">
+                                Task not found.
+                            </div>
+                        {% else %}
+                            <div class="alert alert-info">Starting…</div>
+                        {% endif %}
                     </div>
-                    {% else %}
-                    <div class="alert alert-info">Starting…</div>
-                    {% endif %}
-                </div>
                 {% endif %}
             </div>
 
             <div class="mt-4" id="results">
                 {% if task and task.results %}
-                <h3 class="h6">Summary</h3>
-                <ul class="list-group">
-                    <li class="list-group-item">Total files: {{ task.results.total_files }}</li>
-                    <li class="list-group-item">Ready to upload: {{ task.results.files_to_upload_count }}</li>
-                    <li class="list-group-item">No file path: {{ task.results.no_file_path }}</li>
-                    <li class="list-group-item">Nested files: {{ task.results.injects_result.nested_files }}</li>
-                    <li class="list-group-item">New translations: {{ task.results.new_translations_count }}</li>
-                </ul>
+                    <h3 class="h6">Summary</h3>
+                    <ul class="list-group">
+                        <li class="list-group-item">Total files: {{ task.results.total_files }}</li>
+                        <li class="list-group-item">Ready to upload: {{ task.results.files_to_upload_count }}</li>
+                        <li class="list-group-item">No file path: {{ task.results.no_file_path }}</li>
+                        <li class="list-group-item">Nested files: {{ task.results.injects_result.nested_files }}</li>
+                        <li class="list-group-item">New translations: {{ task.results.new_translations_count }}</li>
+                    </ul>
                 {% endif %}
             </div>
         </div>
-        {% endif %}
-    </div>
+    {% endif %}
+{% endblock %}
 
+{% block extra_js %}
     <script>
         (function () {
             const section = document.getElementById('progress-section');
@@ -123,7 +120,6 @@
                     const res = await fetch(`/status/${taskId}`);
                     const taskData = await res.json();
                     if (!res.ok) {
-                        // Stop polling on completion or error
                         if (taskData?.error === 'not-found') {
                             document.getElementById("task_status").innerText = " (Not Found)";
                             document.getElementById("alert_div").innerHTML = `
@@ -136,20 +132,13 @@
                         return;
                     }
 
-                    // Update stages
                     const stagesContainer = document.getElementById('stages');
                     if (taskData.data && taskData.data.stages && stagesContainer) {
-                        // ---
                         let stages_obj = taskData.data.stages;
-                        // {"initialize":{"number": 1, "message":"Starting workflow","status":"Running"}, ... }
-                        // ---
-                        // sort stages_obj by number
                         stages_obj = Object.fromEntries(Object.entries(stages_obj).sort((a, b) => a[1].number - b[1].number));
-                        // ---
                         stagesContainer.innerHTML = Object.entries(stages_obj).map(([name, st]) => stages_html(st, name)).join('');
                     }
 
-                    // Update results
                     const results = document.getElementById('results');
                     if (taskData && taskData.results && results) {
                         const r = taskData.results;
@@ -160,7 +149,6 @@
                         document.getElementById("task_status").innerText = ` (${taskData.status})`;
                     }
 
-                    // Stop polling on completion or error
                     if (['Completed', 'error', 'Failed'].includes(taskData.status)) {
                         clearInterval(timer);
                     }
@@ -171,6 +159,4 @@
             refresh();
         })();
     </script>
-</body>
-
-</html>
+{% endblock %}

--- a/src/web/templates/tasks.html
+++ b/src/web/templates/tasks.html
@@ -1,0 +1,82 @@
+{% extends "base.html" %}
+
+{% block title %}All Tasks · SVG Translate Bot{% endblock %}
+
+{% block extra_css %}
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">
+    <link rel="stylesheet" href="https://cdn.datatables.net/responsive/2.5.0/css/responsive.bootstrap5.min.css">
+{% endblock %}
+
+{% block content %}
+    <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4 gap-3">
+        <h1 class="h3 mb-0">All Tasks</h1>
+        <form class="row g-2 align-items-center" method="get" role="search">
+            <div class="col-auto">
+                <label class="form-label mb-0" for="status">Status</label>
+            </div>
+            <div class="col-auto">
+                <select class="form-select" id="status" name="status">
+                    <option value="">All statuses</option>
+                    {% for status in available_statuses %}
+                        <option value="{{ status }}" {% if status_filter == status %}selected{% endif %}>{{ status }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="col-auto">
+                <button type="submit" class="btn btn-outline-primary">Filter</button>
+            </div>
+        </form>
+    </div>
+    <div class="table-responsive">
+        <table id="tasks-table" class="table table-striped table-hover align-middle" style="width:100%">
+            <thead>
+                <tr>
+                    <th scope="col">Task ID</th>
+                    <th scope="col">Title</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Files Ready</th>
+                    <th scope="col">New Translations</th>
+                    <th scope="col">Created</th>
+                    <th scope="col">Updated</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for task in tasks %}
+                    <tr>
+                        <td><code>{{ task.id }}</code></td>
+                        <td class="text-break">{{ task.title }}</td>
+                        <td>
+                            <span class="badge {% if task.status in ['Completed', 'Failed', 'Running'] %}bg-{{ 'success' if task.status == 'Completed' else 'danger' if task.status == 'Failed' else 'primary' }}{% else %}bg-secondary{% endif %}">{{ task.status }}</span>
+                        </td>
+                        <td>{{ task.files_to_upload_count }}</td>
+                        <td>{{ task.new_translations_count }}</td>
+                        <td data-order="{{ task.created_at_sort }}">{{ task.created_at_display }}</td>
+                        <td data-order="{{ task.updated_at_sort }}">{{ task.updated_at_display }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://cdn.datatables.net/responsive/2.5.0/js/dataTables.responsive.min.js"></script>
+    <script src="https://cdn.datatables.net/responsive/2.5.0/js/responsive.bootstrap5.min.js"></script>
+    <script>
+        $(document).ready(function () {
+            $('#tasks-table').DataTable({
+                responsive: true,
+                pageLength: 25,
+                order: [[5, 'desc']],
+                columnDefs: [
+                    { targets: 0, responsivePriority: 1 },
+                    { targets: 1, responsivePriority: 2 },
+                    { targets: [3, 4], className: 'text-center' }
+                ]
+            });
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a shared base template with Bootstrap navigation and container spacing
- refactor existing index templates to extend the shared layout
- add a task listing route, helper, and template with DataTables enhancements

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68f487a2902c83228deb35e205e4521f