### PR TITLE
Add introductory alert for idle SVG translation form

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -66,6 +66,16 @@
         </div>
     </form>
 
+    {% if not task_id %}
+        <div class="alert alert-secondary" role="alert">
+            This tool automates translating and preparing Wikimedia Commons SVG graphics: given a template
+            title, it fetches the template’s wikitext, identifies the referenced SVG files, downloads the main
+            graphic, extracts its translatable text, applies those translations to the related SVGs, saves the
+            updated files locally, and produces stats that make the translated assets ready to upload back to
+            Commons.
+        </div>
+    {% endif %}
+
     {% if task_id %}
         <div id="progress-section" data-task-id="{{ task_id }}">
             <h2 class="h5">


### PR DESCRIPTION
## Summary
- add an informational alert below the task form when no task is running
- describe the automated workflow for translating Wikimedia Commons SVG graphics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f4b93cd5288322bddffc25c734061b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an informational alert that displays when no task is active, providing an overview of the tool's workflow and helping users understand how to get started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->