### PR TITLE
Address cookie header forwarding and optional crypto key

### DIFF
--- a/src/app/cookies/__init__.py
+++ b/src/app/cookies/__init__.py
@@ -32,11 +32,29 @@ class CookieHeaderClient(FlaskClient):
         if raw_cookie:
             parsed = SimpleCookie()
             parsed.load(raw_cookie)
-            server_name = self.application.config.get("SERVER_NAME")
+            server_name = self.application.config.get("SERVER_NAME") or "localhost"
             for key, morsel in parsed.items():
-                if server_name:
-                    super().set_cookie(key, morsel.value, domain=server_name)
-                else:
-                    super().set_cookie(key, morsel.value)
+                cookie_params: dict[str, Any] = {}
+
+                if morsel["expires"]:
+                    cookie_params["expires"] = morsel["expires"]
+                if morsel["path"]:
+                    cookie_params["path"] = morsel["path"]
+                if morsel["domain"]:
+                    cookie_params["domain"] = morsel["domain"]
+                if morsel["max-age"]:
+                    max_age_value = morsel["max-age"]
+                    try:
+                        cookie_params["max_age"] = int(max_age_value)
+                    except (TypeError, ValueError):
+                        cookie_params["max_age"] = max_age_value
+                if morsel["secure"]:
+                    cookie_params["secure"] = True
+                if morsel["httponly"]:
+                    cookie_params["httponly"] = True
+                if morsel["samesite"]:
+                    cookie_params["samesite"] = morsel["samesite"]
+
+                super().set_cookie(server_name, key, morsel.value, **cookie_params)
 
         return super().open(*args, **kwargs)

--- a/src/app/crypto.py
+++ b/src/app/crypto.py
@@ -7,27 +7,47 @@ from cryptography.fernet import Fernet, InvalidToken
 
 OAUTH_ENCRYPTION_KEY = os.getenv("OAUTH_ENCRYPTION_KEY", "")
 
-if not OAUTH_ENCRYPTION_KEY:
-    raise RuntimeError(
-        "OAUTH_ENCRYPTION_KEY must be configured before using the crypto helpers"
+_fernet: Fernet | None = None
+
+
+def _require_fernet() -> Fernet:
+    global _fernet
+
+    if _fernet is not None:
+        return _fernet
+
+    if not OAUTH_ENCRYPTION_KEY:
+        raise RuntimeError(
+            "OAUTH_ENCRYPTION_KEY must be configured before using the crypto helpers"
+        )
+
+    key_bytes = (
+        OAUTH_ENCRYPTION_KEY.encode()
+        if isinstance(OAUTH_ENCRYPTION_KEY, str)
+        else OAUTH_ENCRYPTION_KEY
     )
 
-key_bytes = OAUTH_ENCRYPTION_KEY.encode() if isinstance(OAUTH_ENCRYPTION_KEY, str) else OAUTH_ENCRYPTION_KEY
+    try:
+        _fernet = Fernet(key_bytes)
+    except ValueError as exc:  # pragma: no cover - invalid configuration
+        raise RuntimeError(
+            "OAUTH_ENCRYPTION_KEY must be a 32-byte urlsafe base64-encoded string"
+        ) from exc
 
-_fernet = Fernet(key_bytes)
+    return _fernet
 
 
 def encrypt_value(value: str) -> bytes:
     """Encrypt a UTF-8 string and return the raw Fernet token bytes."""
 
-    return _fernet.encrypt(value.encode("utf-8"))
+    return _require_fernet().encrypt(value.encode("utf-8"))
 
 
 def decrypt_value(token: bytes) -> str:
     """Decrypt a Fernet token and return the UTF-8 string contents."""
 
     try:
-        decrypted = _fernet.decrypt(token)
+        decrypted = _require_fernet().decrypt(token)
     except InvalidToken as exc:
         raise ValueError("Unable to decrypt stored token") from exc
     return decrypted.decode("utf-8")


### PR DESCRIPTION
## Summary
- ensure the CookieHeaderClient passes the application server name to FlaskClient.set_cookie and preserves parsed cookie attributes
- lazily construct the Fernet helper so the crypto module can be imported when OAuth encryption is disabled
- raise a clear runtime error when an invalid Fernet key is supplied

## Testing
- pytest *(fails: upstream test environment lacks CopySvgTranslate.* modules and hits circular imports in web routes)*

------
https://chatgpt.com/codex/tasks/task_e_68f9d092f8e48322adae3a773d16e3ef