### PR TITLE
Guard mark_token_used database creation errors

### DIFF
--- a/src/app/users/store.py
+++ b/src/app/users/store.py
@@ -43,8 +43,8 @@ def close_cached_db() -> None:
 def mark_token_used(user_id: int) -> None:
     """Update the last-used timestamp for the given user token."""
 
-    db = _get_db()
     try:
+        db = _get_db()
         db.execute_query(
             "UPDATE user_tokens SET last_used_at = CURRENT_TIMESTAMP WHERE user_id = %s",
             (user_id,),


### PR DESCRIPTION
## Summary
- wrap `_get_db()` and the update query in `mark_token_used` with an exception handler so connection failures are logged instead of propagating

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9cfe07a248322af4528c345afb3bb