### PR TITLE
Add stop and restart controls to task status page

### DIFF
--- a/src/svg_config.py
+++ b/src/svg_config.py
@@ -1,0 +1,3 @@
+"""Compatibility wrapper for legacy imports of svg_config."""
+
+from .app.svg_config import *  # noqa: F401,F403

--- a/src/templates/task2.html
+++ b/src/templates/task2.html
@@ -53,15 +53,42 @@
 </form>
 {% if task_id %}
 <div id="progress-section" data-task-id="{{ task_id }}">
-    <h2 class="h5">
-        Task Status <span id="task_status">
-            {% if task %}
-            ({{ task.status if task.status else ("Not Found" if task.error == 'not-found' else "") }})
-            {% endif %}
-        </span>
-    </h2>
+    {% set status_classes = {
+        'Completed': 'success',
+        'Failed': 'danger',
+        'Skipped': 'warning',
+        'Running': 'primary',
+        'Pending': 'secondary',
+        'Cancelled': 'warning',
+        'error': 'danger'
+    } %}
+    {% set current_status = task.status if task and task.status else '' %}
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h2 class="h5 m-0 d-flex align-items-center gap-2">
+            <span>Task Status</span>
+            <span id="task_status" data-status="{{ current_status }}">
+                {% if current_status %}
+                <span class="badge text-bg-{{ status_classes.get(current_status, 'secondary') }}">{{ current_status }}</span>
+                {% elif task and task.error == 'not-found' %}
+                <span class="badge text-bg-danger">Not Found</span>
+                {% endif %}
+            </span>
+        </h2>
+        {% set hide_cancel = (current_status in ['Completed', 'Failed', 'Cancelled']) or (task and task.error == 'not-found') %}
+        {% set show_restart = current_status in ['Completed', 'Failed', 'Cancelled'] %}
+        <div class="btn-group" role="group" aria-label="Task actions">
+            <button type="button" class="btn btn-outline-danger {% if hide_cancel %}d-none{% endif %}"
+                id="cancel-task-btn" data-task-id="{{ task_id }}">
+                Stop
+            </button>
+            <button type="button" class="btn btn-outline-primary {% if not show_restart %}d-none{% endif %}"
+                id="restart-task-btn" data-task-id="{{ task_id }}">
+                Restart
+            </button>
+        </div>
+    </div>
 
-    <div class="d-flex justify-content-between align-items-center">
+    <div class="d-flex flex-wrap gap-2 justify-content-between align-items-center">
         <div id="task-meta" class="mb-2 text-muted">
             <a href="/status/{{ task_id }}" target="_blank">Task ID:</a> <code>{{ task_id }}</code>
         </div>
@@ -80,7 +107,8 @@
         'Failed': 'danger',
         'Skipped': 'warning',
         'Running': 'primary',
-        'Pending': 'secondary'
+        'Pending': 'secondary',
+        'Cancelled': 'warning'
     } %}
     <ul id="stagesnew" class="list-group">
         {% for name, st in stages %}

--- a/tests/test_task2_ui.py
+++ b/tests/test_task2_ui.py
@@ -1,0 +1,106 @@
+import re
+
+import pytest
+
+from src.app import create_app
+from src.app.tasks import routes as task_routes
+
+
+class DummyStore:
+    def __init__(self, task):
+        self._task = task
+
+    def get_task(self, task_id):  # pragma: no cover - trivial
+        return self._task
+
+
+@pytest.fixture
+def app_factory(monkeypatch):
+    def _factory(task):
+        app = create_app()
+        app.config["TESTING"] = True
+        monkeypatch.setattr(task_routes, "TASK_STORE", None)
+        monkeypatch.setattr(task_routes, "_get_task_store", lambda: DummyStore(task))
+        return app
+
+    return _factory
+
+
+def _get_button_classes(html, button_id):
+    block_pattern = rf'<[^>]*id="{button_id}"[^>]*>'
+    match = re.search(block_pattern, html)
+    assert match, f"Button with id={button_id} not found"
+    class_match = re.search(r'class="([^"]+)"', match.group(0))
+    assert class_match, f"Button with id={button_id} does not have a class attribute"
+    return class_match.group(1)
+
+
+def test_task2_active_shows_cancel_button(app_factory):
+    task = {
+        "id": "running-task",
+        "title": "Demo",
+        "status": "Running",
+        "stages": {
+            "Download": {"status": "Running", "number": 1}
+        },
+    }
+    app = app_factory(task)
+    with app.test_client() as client:
+        response = client.get("/task2", query_string={"task_id": task["id"]})
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+
+    cancel_classes = _get_button_classes(html, "cancel-task-btn")
+    assert "d-none" not in cancel_classes
+    assert f'data-task-id="{task["id"]}"' in html
+
+    restart_classes = _get_button_classes(html, "restart-task-btn")
+    assert "d-none" in restart_classes
+    assert "badge text-bg-primary" in html  # running badge
+
+
+def test_task2_terminal_shows_restart_button(app_factory):
+    task = {
+        "id": "complete-task",
+        "title": "Demo",
+        "status": "Completed",
+        "stages": {
+            "Download": {"status": "Completed", "number": 1}
+        },
+    }
+    app = app_factory(task)
+    with app.test_client() as client:
+        response = client.get("/task2", query_string={"task_id": task["id"]})
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+
+    cancel_classes = _get_button_classes(html, "cancel-task-btn")
+    assert "d-none" in cancel_classes
+
+    restart_classes = _get_button_classes(html, "restart-task-btn")
+    assert "d-none" not in restart_classes
+    assert f'data-task-id="{task["id"]}"' in html
+    assert "badge text-bg-success" in html
+
+
+def test_stage_cancelled_renders_warning_badge(app_factory):
+    task = {
+        "id": "cancelled-task",
+        "title": "Demo",
+        "status": "Cancelled",
+        "stages": {
+            "Upload": {"status": "Cancelled", "number": 1}
+        },
+    }
+    app = app_factory(task)
+    with app.test_client() as client:
+        response = client.get("/task2", query_string={"task_id": task["id"]})
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+
+    header_badge = re.search(r'id="task_status"[^<]*<span class="badge ([^"]+)"', html)
+    assert header_badge, "Expected status badge in header"
+    assert "text-bg-warning" in header_badge.group(1)
+    assert "Cancelled" in html
+
+    assert 'badge text-bg-warning border border-warning">Cancelled' in html


### PR DESCRIPTION
## Summary
- add stop and restart controls with status badges on the task2 progress header
- extend task.js to handle cancel and restart actions, including Cancelled state rendering
- add a shim for svg_config imports and tests covering the new UI controls

## Testing
- USE_MW_OAUTH=0 FLASK_SECRET_KEY=test OAUTH_ENCRYPTION_KEY=MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY= pytest tests/test_task2_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68fb582750908322959ce8529ef1cfeb