### PR TITLE
Add task cancellation and restart controls

### DIFF
--- a/src/app/db/task_store_pymysql.py
+++ b/src/app/db/task_store_pymysql.py
@@ -7,7 +7,7 @@ from .db_class import Database
 from .utils import _serialize, _normalize_title, _deserialize, _current_ts
 
 logger = logging.getLogger(__name__)
-TERMINAL_STATUSES = ("Completed", "Failed")
+TERMINAL_STATUSES = ("Completed", "Failed", "Cancelled")
 
 
 class TaskAlreadyExistsError(Exception):

--- a/src/app/tasks/routes.py
+++ b/src/app/tasks/routes.py
@@ -17,6 +17,7 @@ from flask import (
     request,
     url_for,
 )
+from werkzeug.datastructures import MultiDict
 
 from ..config import settings
 from ..svg_config import DISABLE_UPLOADS
@@ -26,6 +27,8 @@ from ..users.current import current_user, oauth_required
 
 TASK_STORE: TaskStorePyMysql | None = None
 TASKS_LOCK = threading.Lock()
+CANCEL_EVENTS: Dict[str, threading.Event] = {}
+CANCEL_EVENTS_LOCK = threading.Lock()
 
 bp_main = Blueprint("main", __name__)
 logger = logging.getLogger(__name__)
@@ -79,6 +82,21 @@ def _task_lock() -> threading.Lock:
     if TASKS_LOCK is None:
         TASKS_LOCK = threading.Lock()
     return TASKS_LOCK
+
+
+def _register_cancel_event(task_id: str, cancel_event: threading.Event) -> None:
+    with CANCEL_EVENTS_LOCK:
+        CANCEL_EVENTS[task_id] = cancel_event
+
+
+def _pop_cancel_event(task_id: str) -> threading.Event | None:
+    with CANCEL_EVENTS_LOCK:
+        return CANCEL_EVENTS.pop(task_id, None)
+
+
+def _get_cancel_event(task_id: str) -> threading.Event | None:
+    with CANCEL_EVENTS_LOCK:
+        return CANCEL_EVENTS.get(task_id)
 
 
 def _format_timestamp(value: datetime | str | None) -> tuple[str, str]:
@@ -148,6 +166,36 @@ def _order_stages(stages: Dict[str, Any] | None) -> List[tuple[str, Dict[str, An
     ]
     ordered.sort(key=lambda item: item[1].get("number", 0))
     return ordered
+
+
+def _launch_task_thread(
+    task_id: str,
+    title: str,
+    args: Any,
+    user_payload: Dict[str, Any],
+) -> None:
+    cancel_event = threading.Event()
+    _register_cancel_event(task_id, cancel_event)
+
+    def _runner() -> None:
+        try:
+            run_task(
+                settings.db_data,
+                task_id,
+                title,
+                args,
+                user_payload,
+                cancel_event=cancel_event,
+            )
+        finally:
+            _pop_cancel_event(task_id)
+
+    t = threading.Thread(
+        target=_runner,
+        name=f"task-runner-{task_id[:8]}",
+        daemon=True,
+    )
+    t.start()
 
 
 @bp_main.get("/")
@@ -261,13 +309,7 @@ def start():
             "access_secret": user.access_secret,
         }
 
-    t = threading.Thread(
-        target=run_task,
-        args=(settings.db_data, task_id, title, args, user_payload),
-        name=f"task-runner-{task_id[:8]}",
-        daemon=True,
-    )
-    t.start()
+    _launch_task_thread(task_id, title, args, user_payload)
 
     return redirect(url_for("main.task1", title=title, task_id=task_id))
 
@@ -321,3 +363,81 @@ def status(task_id: str):
         return jsonify({"error": "not-found"}), 404
 
     return jsonify(task)
+
+
+@bp_main.post("/tasks/<task_id>/cancel")
+def cancel(task_id: str):
+    if not task_id:
+        return jsonify({"error": "no-task-id"}), 400
+
+    store = _get_task_store()
+    task = store.get_task(task_id)
+    if not task:
+        logger.debug("Cancel requested for missing task %s", task_id)
+        return jsonify({"error": "not-found"}), 404
+
+    cancel_event = _get_cancel_event(task_id)
+    if cancel_event:
+        cancel_event.set()
+
+    store.update_status(task_id, "Cancelled")
+
+    return jsonify({"task_id": task_id, "status": "Cancelled"})
+
+
+@bp_main.post("/tasks/<task_id>/restart")
+def restart(task_id: str):
+    if not task_id:
+        return jsonify({"error": "no-task-id"}), 400
+
+    store = _get_task_store()
+    task = store.get_task(task_id)
+    if not task:
+        logger.debug("Restart requested for missing task %s", task_id)
+        return jsonify({"error": "not-found"}), 404
+
+    title = task.get("title")
+    if not title:
+        logger.error("Task %s has no title to restart", task_id)
+        return jsonify({"error": "no-title"}), 400
+
+    stored_form = dict(task.get("form") or {})
+    request_form = MultiDict(stored_form.items()) if stored_form else MultiDict()
+    args = parse_args(request_form)
+
+    new_task_id = uuid.uuid4().hex
+
+    with TASKS_LOCK:
+        try:
+            store.create_task(
+                new_task_id,
+                title,
+                username=task.get("username", ""),
+                form=stored_form,
+            )
+        except TaskAlreadyExistsError as exc:
+            existing = exc.task
+            logger.debug(
+                "Restart for %s blocked by existing task %s", task_id, existing.get("id")
+            )
+            return (
+                jsonify({"error": "task-active", "task_id": existing.get("id")}),
+                409,
+            )
+        except Exception:
+            logger.exception("Failed to restart task %s", task_id)
+            return jsonify({"error": "task-create-failed"}), 500
+
+    user = current_user()
+    user_payload: Dict[str, Any] = {}
+    if user:
+        user_payload = {
+            "id": user.user_id,
+            "username": user.username,
+            "access_token": user.access_token,
+            "access_secret": user.access_secret,
+        }
+
+    _launch_task_thread(new_task_id, title, args, user_payload)
+
+    return jsonify({"task_id": new_task_id})

--- a/src/app/web/web_run_task.py
+++ b/src/app/web/web_run_task.py
@@ -2,6 +2,7 @@
 import os
 import re
 import logging
+import threading
 from pathlib import Path
 from typing import Any, Dict
 
@@ -139,6 +140,8 @@ def run_task(
     title: str,
     args: Any,
     user_data: Dict[str, str] | None,
+    *,
+    cancel_event: threading.Event | None = None,
 ) -> None:
     """Execute the full SVG translation pipeline for a queued task.
 
@@ -164,18 +167,40 @@ def run_task(
 
         # store.replace_stages(task_id, stages_list)
 
-        store.update_data(task_id, task_snapshot)
-        store.update_status(task_id, "Running")
-
         def push_stage(stage_name: str, stage_state: Dict[str, Any] | None = None) -> None:
             """Persist the latest state for a workflow stage to the database."""
             state = stage_state if stage_state is not None else stages_list[stage_name]
             store.update_stage(task_id, stage_name, state)
 
+        store.update_data(task_id, task_snapshot)
+
+        def check_cancel(stage_name: str | None = None) -> bool:
+            if cancel_event is None or not cancel_event.is_set():
+                return False
+
+            if stage_name:
+                stage_state = stages_list.get(stage_name)
+                if stage_state and stage_state.get("status") == "Running":
+                    stage_state["status"] = "Cancelled"
+                    push_stage(stage_name, stage_state)
+
+            stages_list["initialize"]["status"] = "Completed"
+            push_stage("initialize")
+            store.update_status(task_id, "Cancelled")
+            return True
+
+        if cancel_event is not None and cancel_event.is_set():
+            if check_cancel("initialize"):
+                return
+
+        store.update_status(task_id, "Running")
+
         # ----------------------------------------------
         # Stage 1: extract text
         text, stages_list["text"] = text_task(stages_list["text"], title)
         push_stage("text")
+        if check_cancel("text"):
+            return
         if not text:
             return fail_task(store, task_id, stages_list, "No text extracted")
 
@@ -183,6 +208,8 @@ def run_task(
         # Stage 2: extract titles
         titles_result, stages_list["titles"] = titles_task(stages_list["titles"], text, titles_limit=args.titles_limit)
         push_stage("titles")
+        if check_cancel("titles"):
+            return
 
         main_title, titles = titles_result["main_title"], titles_result["titles"]
 
@@ -198,6 +225,8 @@ def run_task(
 
         translations, stages_list["translations"] = translations_task(stages_list["translations"], main_title, output_dir_main)
         push_stage("translations")
+        if check_cancel("translations"):
+            return
 
         if not translations:
             return fail_task(store, task_id, stages_list, "No translations available")
@@ -212,6 +241,8 @@ def run_task(
             store
         )
         push_stage("download")
+        if check_cancel("download"):
+            return
 
         if not files:
             return fail_task(store, task_id, stages_list, "No files downloaded")
@@ -220,6 +251,8 @@ def run_task(
         # Stage 5: inject translations
         injects_result, stages_list["inject"] = inject_task(stages_list["inject"], files, translations, output_dir=output_dir, overwrite=args.overwrite)
         push_stage("inject")
+        if check_cancel("inject"):
+            return
 
         if not injects_result or injects_result.get("saved_done", 0) == 0:
             return fail_task(store, task_id, stages_list, "Injection saved 0 files")
@@ -243,6 +276,8 @@ def run_task(
         )
 
         push_stage("upload")
+        if check_cancel("upload"):
+            return
 
         # ----------------------------------------------
         # Stage 7: save stats and mark done
@@ -271,5 +306,8 @@ def run_task(
         final_status = "Failed" if any(s.get("status") == "Failed" for s in stages_list.values()) else "Completed"
         stages_list["initialize"]["status"] = "Completed"
         push_stage("initialize")
+
+        if check_cancel("initialize"):
+            return
 
         store.update_status(task_id, final_status)

--- a/src/svg_config.py
+++ b/src/svg_config.py
@@ -1,0 +1,19 @@
+"""Compatibility wrapper for legacy ``src.svg_config`` imports."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_NAME = "src.app.svg_config"
+_MODULE_PATH = Path(__file__).resolve().parent / "app" / "svg_config.py"
+_spec = importlib.util.spec_from_file_location(_MODULE_NAME, _MODULE_PATH)
+if _spec is None or _spec.loader is None:  # pragma: no cover - defensive
+    raise ImportError(f"Cannot load module {_MODULE_NAME} from {_MODULE_PATH}")
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+
+for _name in getattr(_module, "__all__", []):
+    globals()[_name] = getattr(_module, _name)
+
+__all__ = getattr(_module, "__all__", [])

--- a/tests/test_task_routes.py
+++ b/tests/test_task_routes.py
@@ -1,0 +1,152 @@
+import threading
+from typing import Any, Dict, Optional
+
+import pytest
+
+from src.app import create_app
+from src.app.tasks import routes
+from src.app.db.task_store_pymysql import TaskAlreadyExistsError
+
+
+class InMemoryTaskStore:
+    def __init__(self) -> None:
+        self.tasks: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def create_task(
+        self,
+        task_id: str,
+        title: str,
+        status: str = "Pending",
+        username: str = "",
+        form: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        with self._lock:
+            if task_id in self.tasks:
+                raise TaskAlreadyExistsError(self.tasks[task_id])
+            self.tasks[task_id] = {
+                "id": task_id,
+                "title": title,
+                "username": username,
+                "status": status,
+                "form": dict(form or {}),
+            }
+
+    def get_task(self, task_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            task = self.tasks.get(task_id)
+            return dict(task) if task else None
+
+    def get_active_task_by_title(self, title: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            for task in self.tasks.values():
+                if task["title"] == title and task["status"] not in {"Completed", "Failed", "Cancelled"}:
+                    return dict(task)
+        return None
+
+    def update_status(self, task_id: str, status: str) -> None:
+        with self._lock:
+            if task_id in self.tasks:
+                updated = dict(self.tasks[task_id])
+                updated["status"] = status
+                self.tasks[task_id] = updated
+
+    def update_stage(self, task_id: str, stage_name: str, stage_state: Dict[str, Any]) -> None:  # pragma: no cover - unused
+        pass
+
+    def update_results(self, task_id: str, results: Dict[str, Any]) -> None:  # pragma: no cover - unused
+        pass
+
+    def update_data(self, task_id: str, data: Dict[str, Any]) -> None:  # pragma: no cover - unused
+        pass
+
+    def close(self) -> None:  # pragma: no cover - interface compatibility
+        pass
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("FLASK_SECRET_KEY", "test-secret")
+    app = create_app()
+    app.config["TESTING"] = True
+    store = InMemoryTaskStore()
+    monkeypatch.setattr(routes, "_get_task_store", lambda: store)
+    routes.TASK_STORE = store
+    routes.TASKS_LOCK = threading.Lock()
+    with routes.CANCEL_EVENTS_LOCK:
+        routes.CANCEL_EVENTS.clear()
+    return app
+
+
+def test_cancel_route_signals_event_and_updates_status(app: Any, monkeypatch: pytest.MonkeyPatch):
+    store: InMemoryTaskStore = routes._get_task_store()  # type: ignore[assignment]
+
+    started = threading.Event()
+    finished = threading.Event()
+
+    def fake_run_task(db_data, task_id, title, args, user_payload, *, cancel_event=None):
+        assert cancel_event is not None
+        started.set()
+        cancel_event.wait(1)
+        finished.set()
+
+    monkeypatch.setattr(routes, "run_task", fake_run_task)
+
+    client = app.test_client()
+    response = client.post("/", data={"title": "Sample"})
+    assert response.status_code == 302
+    assert started.wait(1)
+
+    task_id = next(iter(store.tasks))
+    with routes.CANCEL_EVENTS_LOCK:
+        cancel_event = routes.CANCEL_EVENTS.get(task_id)
+    assert cancel_event is not None and not cancel_event.is_set()
+
+    cancel_response = client.post(f"/tasks/{task_id}/cancel")
+    assert cancel_response.status_code == 200
+    payload = cancel_response.get_json()
+    assert payload == {"task_id": task_id, "status": "Cancelled"}
+
+    assert store.tasks[task_id]["status"] == "Cancelled"
+
+    assert finished.wait(1)
+    with routes.CANCEL_EVENTS_LOCK:
+        assert task_id not in routes.CANCEL_EVENTS
+
+
+def test_restart_route_creates_new_task_and_replays_form(app: Any, monkeypatch: pytest.MonkeyPatch):
+    store: InMemoryTaskStore = routes._get_task_store()  # type: ignore[assignment]
+
+    existing_id = "existing"
+    store.create_task(existing_id, "Title", form={"title": "Title", "titles_limit": "5", "upload": "on"})
+    store.update_status(existing_id, "Cancelled")
+
+    captured: Dict[str, Any] = {}
+
+    def fake_run_task(db_data, task_id, title, args, user_payload, *, cancel_event=None):
+        captured["task_id"] = task_id
+        captured["title"] = title
+        captured["args"] = args
+        captured["user_payload"] = user_payload
+        captured["cancel_event"] = cancel_event
+
+    monkeypatch.setattr(routes, "run_task", fake_run_task)
+
+    client = app.test_client()
+    restart_response = client.post(f"/tasks/{existing_id}/restart")
+    assert restart_response.status_code == 200
+    payload = restart_response.get_json()
+    new_task_id = payload["task_id"]
+
+    assert new_task_id != existing_id
+    assert new_task_id in store.tasks
+    assert store.tasks[new_task_id]["title"] == "Title"
+    assert store.tasks[new_task_id]["form"] == {"title": "Title", "titles_limit": "5", "upload": "on"}
+
+    assert captured["task_id"] == new_task_id
+    assert captured["title"] == "Title"
+    assert hasattr(captured["args"], "titles_limit")
+    assert captured["args"].titles_limit == 5
+    assert captured["cancel_event"] is not None
+    with routes.CANCEL_EVENTS_LOCK:
+        assert new_task_id not in routes.CANCEL_EVENTS


### PR DESCRIPTION
## Summary
- track cancellation events for running tasks and expose cancel/restart endpoints
- update the task runner to respect cancellation events and treat "Cancelled" as a terminal status
- add a compatibility svg_config shim and tests that cover cancel and restart flows

## Testing
- FLASK_SECRET_KEY=test USE_MW_OAUTH=0 OAUTH_ENCRYPTION_KEY=spt1W9-IBiCLE4fsxLeaEIJz1L9Kd1d0qM_Ddv6Gk2U= pytest tests/test_task_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68fb53e7032c8322ad273be16922a4c9