### PR TITLE
Fix task thread run_task reference and re-enable cancel lifecycle test

### DIFF
--- a/src/app/threads/task_threads.py
+++ b/src/app/threads/task_threads.py
@@ -7,7 +7,7 @@ import logging
 from typing import Any, Dict
 
 from ..config import settings
-from .web_run_task import run_task
+from . import web_run_task
 
 CANCEL_EVENTS: Dict[str, threading.Event] = {}
 CANCEL_EVENTS_LOCK = threading.Lock()
@@ -42,7 +42,7 @@ def launch_task_thread(
 
     def _runner() -> None:
         try:
-            run_task(
+            web_run_task.run_task(
                 settings.db_data,
                 task_id,
                 title,

--- a/tests/test_task_threads.py
+++ b/tests/test_task_threads.py
@@ -9,14 +9,16 @@ from src.app.threads.task_threads import (
 from src.app.threads import web_run_task
 
 
-def _test_launch_thread_registers_and_cleans_cancel_event(monkeypatch):
+def test_launch_thread_registers_and_cleans_cancel_event(monkeypatch):
     # TODO: FAILED tests/test_task_threads.py::test_launch_thread_registers_and_cleans_cancel_event - AssertionError: Thread did not start in time
     started = threading.Event()
     release = threading.Event()
 
-    def fake_run_task(_db_data, _task_id, _title, _args, _user_payload, *, _cancel_event=None):  # pylint: disable=too-many-arguments
+    def fake_run_task(_db_data, _task_id, _title, _args, _user_payload, *, cancel_event=None):  # pylint: disable=too-many-arguments
         # signal we started and wait briefly until released
         started.set()
+        if cancel_event is not None:
+            assert cancel_event.is_set() is False
         release.wait(timeout=0.2)
 
     monkeypatch.setattr(web_run_task, "run_task", fake_run_task)


### PR DESCRIPTION
## Summary
- import the task runner module so monkeypatches affect launch_task_thread
- re-enable the cancel-event lifecycle test with stronger assertions

## Testing
- pytest tests/test_task_threads.py

------
https://chatgpt.com/codex/tasks/task_e_68ff2e31ffc88322af27900dbc7124a8