### PR TITLE
Ensure cancelled task status renders warning badge

### DIFF
--- a/src/templates/task2.html
+++ b/src/templates/task2.html
@@ -109,14 +109,14 @@
         <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
             <h2 class="h5 m-0 d-flex align-items-center gap-2">
                 <span>Task Status</span>
-                <span id="task_status" data-status="{{ current_status }}">
-                    {% if current_status %}
-                    <span
-                        class="badge text-bg-{{ status_classes.get(current_status, 'secondary') }}">{{ current_status }}</span>
-                    {% elif task and task.error == 'not-found' %}
-                    <span class="badge text-bg-danger">Not Found</span>
-                    {% endif %}
-                </span>
+                {% if current_status %}
+                <span id="task_status" data-status="{{ current_status }}"
+                    class="badge text-bg-{{ status_classes.get(current_status, 'secondary') }}">{{ current_status }}</span>
+                {% elif task and task.error == 'not-found' %}
+                <span id="task_status" data-status="" class="badge text-bg-danger">Not Found</span>
+                {% else %}
+                <span id="task_status" data-status=""></span>
+                {% endif %}
             </h2>
             {% set hide_cancel = (current_status in ['Completed', 'Failed', 'Cancelled', 'error']) or (task and task.error == 'not-found') %}
             {% set show_restart = current_status in ['Completed', 'Failed', 'Cancelled'] %}


### PR DESCRIPTION
## Summary
- ensure the task status header applies the warning badge class directly to the `task_status` span
- harden the task2 UI tests by isolating coordinator initialization and checking for warning badges with newline-tolerant matching

## Testing
- pytest tests/test_task2_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68ff2e3906548322bdea5a5e144bdddf