### PR TITLE
Fix stage fetching fallback in DbUtils

### DIFF
--- a/src/app/db/utils.py
+++ b/src/app/db/utils.py
@@ -80,6 +80,13 @@ class DbUtils:
                 - updated_at: ISO 8601 timestamp string if available, otherwise string representation
                 - stages: Mapping of stage names to stage details
         """
+        if stages is None:
+            # Only fall back to fetching stages from the database when no
+            # pre-computed mapping was provided. This ensures that an empty
+            # dict coming from a join (meaning "no stages") is preserved
+            # without triggering an additional query.
+            stages = self.fetch_stages(row["id"])
+
         return {
             "id": row["id"],
             "username": row.get("username", ""),

--- a/tests/test_task_store_pymysql.py
+++ b/tests/test_task_store_pymysql.py
@@ -167,8 +167,7 @@ def test_list_tasks_joins_stages_and_returns_stage_data(store_and_db):
     assert tasks[0]["stages"]["process"]["number"] == 2
     assert tasks[1]["stages"] == {}
 
-    # TODO: FAILED tests/test_task_store_pymysql.py::test_list_tasks_joins_stages_and_returns_stage_data - AssertionError: Expected 'mock' to not have been called. Called 1 times.
-    # store.fetch_stages.assert_not_called()
+    store.fetch_stages.assert_not_called()
 
 
 def test_get_task_joins_and_groups_stages(store_and_db):


### PR DESCRIPTION
## Summary
- ensure `DbUtils._row_to_task` only calls `fetch_stages` when no stage mapping is provided
- restore the stage join test assertion to verify `fetch_stages` is not called when join data is present

## Testing
- `pytest tests/test_task_store_pymysql.py`


------
https://chatgpt.com/codex/tasks/task_e_68ff2e3b96f48322a15c18d60af7bd95