### PR TITLE
Force English 12-hour timestamps for stage updates

### DIFF
--- a/src/static/js/task.js
+++ b/src/static/js/task.js
@@ -26,13 +26,21 @@ function formatStageTimestamp(updatedAtRaw) {
     }
 
     try {
-        return date.toLocaleString(undefined, {
+        return date.toLocaleString('en-US', {
             dateStyle: 'medium',
             timeStyle: 'short',
+            hour12: true,
         });
     } catch (err) {
         // Fallback for browsers that don't support dateStyle/timeStyle options
-        return date.toLocaleString();
+        return date.toLocaleString('en-US', {
+            hour: 'numeric',
+            minute: '2-digit',
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour12: true,
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- render stage timestamps using the English locale to ensure AM/PM output
- add an English fallback formatting path for browsers without dateStyle/timeStyle support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6901998f894883228e9c3a95d24ad1d4