### PR TITLE
Use deepcopy for template data iteration

### DIFF
--- a/src/app/app_routes/templates/routes.py
+++ b/src/app/app_routes/templates/routes.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import logging
 import re
 import json
+import copy
 
 from flask import (
     Blueprint,
@@ -51,7 +52,7 @@ def temps_main_files(data: dict) -> dict:
     # ---
     temp_list = {x.title: x.main_file for x in get_templates_db().list() if x.main_file}
     # ---
-    for title in data.copy().keys():
+    for title in copy.deepcopy(data).keys():
         # ---
         data[title].setdefault("main_file", "")
         # ---


### PR DESCRIPTION
## Summary
- import the copy module for deep copies in template routes
- replace dict.copy usage with copy.deepcopy before iterating keys

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69084d7726888322bfb27977d474c2a0