### PR TITLE
Add coverage for remaining app route tests

### DIFF
--- a/tests/app/app_routes/admin/test_admins_required.py
+++ b/tests/app/app_routes/admin/test_admins_required.py
@@ -1,14 +1,54 @@
-"""
+"""Tests for admin access decorator."""
 
-Tests
+from __future__ import annotations
 
-"""
+import types
+
 import pytest
 
-from src.app.app_routes.admin.admins_required import admin_required
+from src.app.app_routes.admin import admins_required
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_admin_required():
-    # TODO: Implement test
-    pass
+def test_admin_required_redirects_when_not_logged_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admins_required, "current_user", lambda: None)
+    monkeypatch.setattr(admins_required, "redirect", lambda location: f"redirect:{location}")
+    monkeypatch.setattr(admins_required, "url_for", lambda endpoint: f"/{endpoint}")
+
+    @admins_required.admin_required
+    def view() -> str:
+        return "ok"
+
+    assert view() == "redirect:/auth.login"
+
+
+def test_admin_required_blocks_non_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admins_required, "current_user", lambda: types.SimpleNamespace(username="user"))
+    monkeypatch.setattr(admins_required, "active_coordinators", lambda: [])
+
+    class AbortCalled(Exception):
+        pass
+
+    def fake_abort(code: int) -> None:
+        raise AbortCalled(code)
+
+    monkeypatch.setattr(admins_required, "abort", fake_abort)
+
+    @admins_required.admin_required
+    def view() -> str:
+        return "ok"
+
+    with pytest.raises(AbortCalled) as excinfo:
+        view()
+
+    assert excinfo.value.args[0] == 403
+
+
+def test_admin_required_allows_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(admins_required, "current_user", lambda: types.SimpleNamespace(username="boss"))
+    monkeypatch.setattr(admins_required, "active_coordinators", lambda: ["boss"])
+
+    @admins_required.admin_required
+    def view() -> str:
+        return "ok"
+
+    assert view() == "ok"

--- a/tests/app/app_routes/admin/test_sidebar.py
+++ b/tests/app/app_routes/admin/test_sidebar.py
@@ -1,18 +1,21 @@
-"""
-Tests
-"""
-import pytest
+"""Tests for sidebar helpers."""
 
-from src.app.app_routes.admin.sidebar import generate_list_item, create_side
+from src.app.app_routes.admin import sidebar
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_generate_list_item():
-    # TODO: Implement test
-    pass
+def test_generate_list_item() -> None:
+    html = sidebar.generate_list_item("/home", "Home", icon="bi-house", target=True)
+
+    assert "href='/home'" in html
+    assert "bi-house" in html
+    assert "target='_blank'" in html
+    assert "Home" in html
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_create_side():
-    # TODO: Implement test
-    pass
+def test_create_side_marks_active_item() -> None:
+    html = sidebar.create_side("coordinators")
+
+    assert "Users" in html
+    assert "coordinators" in html
+    assert "active" in html
+    assert html.count("<ul") >= 2

--- a/tests/app/app_routes/auth/test_cookie.py
+++ b/tests/app/app_routes/auth/test_cookie.py
@@ -1,30 +1,62 @@
-"""
-Tests
-"""
+"""Tests for cookie helpers."""
+
+from __future__ import annotations
+
+import types
+
 import pytest
+from itsdangerous import URLSafeTimedSerializer
 
-from src.app.app_routes.auth.cookie import sign_user_id, extract_user_id, sign_state_token, verify_state_token
-
-
-@pytest.mark.skip(reason="Pending write")
-def test_sign_user_id():
-    # TODO: Implement test
-    pass
+from src.app.app_routes.auth import cookie
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_extract_user_id():
-    # TODO: Implement test
-    pass
+@pytest.fixture(autouse=True)
+def configure_serializers(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_cookie = types.SimpleNamespace(max_age=3600)
+    fake_settings = types.SimpleNamespace(secret_key="secret", cookie=fake_cookie)
+    serializer = URLSafeTimedSerializer(fake_settings.secret_key, salt="svg-translate-uid")
+    state_serializer = URLSafeTimedSerializer(fake_settings.secret_key, salt="svg-translate-oauth-state")
+
+    monkeypatch.setattr(cookie, "settings", fake_settings)
+    monkeypatch.setattr(cookie, "_serializer", serializer)
+    monkeypatch.setattr(cookie, "_state_serializer", state_serializer)
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_sign_state_token():
-    # TODO: Implement test
-    pass
+def test_sign_user_id() -> None:
+    token = cookie.sign_user_id(123)
+
+    data = cookie._serializer.loads(token)
+    assert data["uid"] == 123
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_verify_state_token():
-    # TODO: Implement test
-    pass
+def test_extract_user_id_valid_token() -> None:
+    token = cookie._serializer.dumps({"uid": 55})
+
+    assert cookie.extract_user_id(token) == 55
+
+
+def test_extract_user_id_invalid_token() -> None:
+    assert cookie.extract_user_id("invalid-token") is None
+
+
+def test_sign_state_token() -> None:
+    token = cookie.sign_state_token("nonce")
+
+    data = cookie._state_serializer.loads(token)
+    assert data["nonce"] == "nonce"
+
+
+def test_verify_state_token_success() -> None:
+    token = cookie._state_serializer.dumps({"nonce": "abc"})
+
+    assert cookie.verify_state_token(token) == "abc"
+
+
+def test_verify_state_token_invalid_payload() -> None:
+    token = cookie._state_serializer.dumps({"not": "nonce"})
+
+    assert cookie.verify_state_token(token) is None
+
+
+def test_verify_state_token_bad_signature() -> None:
+    assert cookie.verify_state_token("bad-token") is None

--- a/tests/app/app_routes/auth/test_oauth.py
+++ b/tests/app/app_routes/auth/test_oauth.py
@@ -1,30 +1,117 @@
-"""
-Tests
-"""
+"""Tests for OAuth helpers."""
+
+from __future__ import annotations
+
+import types
+
 import pytest
 
-from src.app.app_routes.auth.oauth import get_handshaker, start_login, complete_login, OAuthIdentityError
+from src.app.app_routes.auth import oauth
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_handshaker():
-    # TODO: Implement test
-    pass
+@pytest.fixture(autouse=True)
+def fake_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    oauth_config = types.SimpleNamespace(
+        consumer_key="consumer",
+        consumer_secret="secret",
+        mw_uri="https://example.com",
+        user_agent="agent",
+    )
+    settings = types.SimpleNamespace(oauth=oauth_config)
+    monkeypatch.setattr(oauth, "settings", settings)
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_start_login():
-    # TODO: Implement test
-    pass
+def test_get_handshaker(monkeypatch: pytest.MonkeyPatch) -> None:
+    created_tokens: list[tuple[str, str]] = []
+    created_handshakers: list[tuple[str, object]] = []
+
+    class DummyHandshaker:
+        def __init__(self, uri: str, *, consumer_token: object, user_agent: str) -> None:
+            created_handshakers.append((uri, consumer_token, user_agent))
+
+    def fake_consumer(key: str, secret: str) -> tuple[str, str]:
+        created_tokens.append((key, secret))
+        return (key, secret)
+
+    monkeypatch.setattr(oauth.mwoauth, "ConsumerToken", fake_consumer)
+    monkeypatch.setattr(oauth.mwoauth, "Handshaker", DummyHandshaker)
+
+    handshaker = oauth.get_handshaker()
+
+    assert isinstance(handshaker, DummyHandshaker)
+    assert created_tokens == [("consumer", "secret")]
+    assert created_handshakers[0][0] == "https://example.com"
+    assert created_handshakers[0][2] == "agent"
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_complete_login():
-    # TODO: Implement test
-    pass
+def test_get_handshaker_without_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oauth, "settings", types.SimpleNamespace(oauth=None))
+
+    with pytest.raises(RuntimeError):
+        oauth.get_handshaker()
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_oauthidentityerror():
-    # TODO: Implement test
-    pass
+def test_start_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_state: list[str] = []
+
+    def fake_url_for(endpoint: str, **params: str) -> str:
+        assert endpoint == "auth.callback"
+        captured_state.append(params["state"])
+        return "https://host/callback"
+
+    class DummyHandshaker:
+        def initiate(self, *, callback: str):
+            assert callback == "https://host/callback"
+            return "https://auth", ("token", "secret")
+
+    monkeypatch.setattr(oauth, "url_for", fake_url_for)
+    monkeypatch.setattr(oauth, "get_handshaker", lambda: DummyHandshaker())
+
+    redirect_url, request_token = oauth.start_login("signed-state")
+
+    assert redirect_url == "https://auth"
+    assert list(request_token) == ["token", "secret"]
+    assert captured_state == ["signed-state"]
+
+
+def test_complete_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyHandshaker:
+        def complete(self, token, query_string: str):
+            assert token == "request-token"
+            assert query_string == "oauth=1"
+            return types.SimpleNamespace(key="k", secret="s")
+
+        def identify(self, token) -> dict:
+            assert token.key == "k"
+            return {"sub": "123", "username": "Tester"}
+
+    monkeypatch.setattr(oauth, "get_handshaker", lambda: DummyHandshaker())
+
+    access_token, identity = oauth.complete_login("request-token", "oauth=1")
+
+    assert access_token.key == "k"
+    assert identity["username"] == "Tester"
+
+
+def test_complete_login_identity_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyHandshaker:
+        def complete(self, token, query_string: str):
+            return "token"
+
+        def identify(self, token) -> dict:
+            raise ValueError("bad")
+
+    monkeypatch.setattr(oauth, "get_handshaker", lambda: DummyHandshaker())
+
+    with pytest.raises(oauth.OAuthIdentityError) as excinfo:
+        oauth.complete_login("request-token", "query")
+
+    assert "MediaWiki" in str(excinfo.value)
+    assert isinstance(excinfo.value.original_exception, ValueError)
+
+
+def test_oauthidentityerror() -> None:
+    error = oauth.OAuthIdentityError("message", original_exception=RuntimeError("boom"))
+
+    assert str(error) == "message"
+    assert isinstance(error.original_exception, RuntimeError)

--- a/tests/app/app_routes/auth/test_rate_limit.py
+++ b/tests/app/app_routes/auth/test_rate_limit.py
@@ -1,12 +1,28 @@
-"""
-Tests
-"""
+"""Tests for the rate limiter."""
+
+from datetime import timedelta
+
 import pytest
 
 from src.app.app_routes.auth.rate_limit import RateLimiter
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_ratelimiter():
-    # TODO: Implement test
-    pass
+def test_ratelimiter_enforces_limit() -> None:
+    limiter = RateLimiter(limit=2, period=timedelta(seconds=60))
+
+    assert limiter.allow("key") is True
+    assert limiter.allow("key") is True
+    assert limiter.allow("key") is False
+
+    remaining = limiter.try_after("key")
+    assert remaining > timedelta(0)
+    assert remaining <= timedelta(seconds=60)
+
+
+@pytest.mark.parametrize("key", ["a", "b"])
+def test_ratelimiter_tracks_keys_independently(key: str) -> None:
+    limiter = RateLimiter(limit=1, period=timedelta(seconds=10))
+
+    assert limiter.allow(key) is True
+    assert limiter.allow(key) is False
+    assert limiter.allow("other") is True

--- a/tests/app/app_routes/cancel_restart/test_cancel_restart_routes.py
+++ b/tests/app/app_routes/cancel_restart/test_cancel_restart_routes.py
@@ -1,24 +1,104 @@
-"""
-Tests
-"""
+"""Tests for cancel and restart routes."""
+
+from __future__ import annotations
+
+import types
+
 import pytest
+from flask import Flask, session
 
-from src.app.app_routes.cancel_restart.routes import login_required_json, cancel, restart
-
-
-@pytest.mark.skip(reason="Pending write")
-def test_login_required_json():
-    # TODO: Implement test
-    pass
+from src.app.app_routes.cancel_restart import routes
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_cancel():
-    # TODO: Implement test
-    pass
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> Flask:
+    app = Flask(__name__)
+    app.secret_key = "secret"
+
+    settings = types.SimpleNamespace(db_data={})
+    monkeypatch.setattr(routes, "settings", settings)
+
+    monkeypatch.setattr(routes, "flash", lambda *args, **kwargs: None)
+    monkeypatch.setattr(routes, "jsonify", lambda payload: payload)
+
+    yield app
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_restart():
-    # TODO: Implement test
-    pass
+def test_login_required_json_blocks_anonymous(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(routes, "current_user", lambda: None)
+
+    @routes.login_required_json
+    def protected() -> dict[str, str]:
+        return {"status": "ok"}
+
+    with app.test_request_context("/"):
+        response = protected()
+
+    assert response == {"error": "login-required"}
+
+
+def test_cancel_happy_path(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    cancel_called = []
+
+    class DummyEvent:
+        def set(self) -> None:
+            cancel_called.append("set")
+
+    class DummyStore:
+        def __init__(self) -> None:
+            self.updated: list[str] = []
+
+        def get_task(self, task_id: str) -> dict[str, str]:
+            return {"id": task_id, "status": "Running", "username": "user"}
+
+        def update_status(self, task_id: str, status: str) -> None:
+            self.updated.append((task_id, status))
+
+    monkeypatch.setattr(routes, "_task_store", lambda: DummyStore())
+    monkeypatch.setattr(routes, "current_user", lambda: types.SimpleNamespace(username="user"))
+    monkeypatch.setattr(routes, "active_coordinators", lambda: ["user"])
+    monkeypatch.setattr(routes, "get_cancel_event", lambda task_id: DummyEvent())
+
+    with app.test_request_context("/tasks/1/cancel"):
+        response = routes.cancel("task")
+
+    assert response == {"task_id": "task", "status": "Cancelled"}
+    assert cancel_called == ["set"]
+
+
+def test_restart_creates_new_task(app: Flask, monkeypatch: pytest.MonkeyPatch) -> None:
+    created_tasks: list[tuple[str, dict[str, str]]] = []
+    launched: list[tuple[str, str]] = []
+
+    class DummyStore:
+        def get_task(self, task_id: str) -> dict[str, object]:
+            return {
+                "id": task_id,
+                "title": "Sample",
+                "username": "user",
+                "form": {"param": "value"},
+            }
+
+        def create_task(self, task_id: str, title: str, *, username: str, form: dict | None = None) -> None:
+            created_tasks.append((task_id, {"title": title, "username": username, "form": form}))
+
+    def fake_parse_args(form):
+        return types.SimpleNamespace(parsed="ok")
+
+    def fake_launch(task_id: str, title: str, args, user_payload: dict) -> None:
+        launched.append((task_id, user_payload["username"]))
+
+    monkeypatch.setattr(routes, "_task_store", lambda: DummyStore())
+    monkeypatch.setattr(routes, "current_user", lambda: types.SimpleNamespace(
+        user_id=1, username="user", access_token="tok", access_secret="sec"
+    ))
+    monkeypatch.setattr(routes, "parse_args", fake_parse_args)
+    monkeypatch.setattr(routes, "uuid", types.SimpleNamespace(uuid4=lambda: types.SimpleNamespace(hex="newtask")))
+    monkeypatch.setattr(routes, "launch_task_thread", fake_launch)
+
+    with app.test_request_context("/tasks/1/restart"):
+        response = routes.restart("task")
+
+    assert response == {"task_id": "newtask", "status": "Running"}
+    assert created_tasks[0][0] == "newtask"
+    assert launched == [("newtask", "user")]

--- a/tests/app/app_routes/explorer/test_compare.py
+++ b/tests/app/app_routes/explorer/test_compare.py
@@ -1,24 +1,47 @@
-"""
-Tests
-"""
-import pytest
+"""Tests for compare utilities."""
 
-from src.app.app_routes.explorer.compare import file_langs, analyze_file, compare_svg_files
+from __future__ import annotations
 
+from pathlib import Path
 
-@pytest.mark.skip(reason="Pending write")
-def test_file_langs():
-    # TODO: Implement test
-    pass
+from src.app.app_routes.explorer import compare
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_analyze_file():
-    # TODO: Implement test
-    pass
+def _write_svg(path: Path, system_languages: list[str]) -> None:
+    texts = "".join(
+        f"<text systemLanguage='{lang}'>Sample</text>" for lang in system_languages
+    )
+    path.write_text(
+        f"""<svg xmlns='http://www.w3.org/2000/svg'>{texts}</svg>""",
+        encoding="utf-8",
+    )
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_compare_svg_files():
-    # TODO: Implement test
-    pass
+def test_file_langs_extracts_languages(tmp_path: Path) -> None:
+    svg = tmp_path / "file.svg"
+    _write_svg(svg, ["fr", "es", "fr"])
+
+    languages = compare.file_langs(svg)
+
+    assert set(languages) == {"en", "fr", "es"}
+
+
+def test_analyze_file_reports_languages(tmp_path: Path) -> None:
+    svg = tmp_path / "doc.svg"
+    _write_svg(svg, ["de"])
+
+    result = compare.analyze_file(svg)
+
+    assert set(result["languages"]) == {"en", "de"}
+
+
+def test_compare_svg_files_returns_both(tmp_path: Path) -> None:
+    original = tmp_path / "orig.svg"
+    translated = tmp_path / "translated.svg"
+    _write_svg(original, ["es"])
+    _write_svg(translated, ["fr"])
+
+    first, second = compare.compare_svg_files(original, translated)
+
+    assert set(first["languages"]) == {"en", "es"}
+    assert set(second["languages"]) == {"en", "fr"}

--- a/tests/app/app_routes/explorer/test_explorer_routes.py
+++ b/tests/app/app_routes/explorer/test_explorer_routes.py
@@ -1,54 +1,150 @@
-"""
-Tests
-"""
+"""Tests for explorer routes."""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
 import pytest
 
-from src.app.app_routes.explorer.routes import by_title_downloaded, by_title_translated, by_title_not_translated, by_title, main, serve_media, serve_thumb, compare
+from src.app.app_routes.explorer import routes
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_by_title_downloaded():
-    # TODO: Implement test
-    pass
+@pytest.fixture
+def patch_templates(monkeypatch: pytest.MonkeyPatch) -> dict:
+    captured: dict[str, dict] = {}
+
+    def fake_render(template: str, **context):
+        captured["template"] = template
+        captured["context"] = context
+        return template
+
+    monkeypatch.setattr(routes, "render_template", fake_render)
+    return captured
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_by_title_translated():
-    # TODO: Implement test
-    pass
+def test_by_title_downloaded_renders_list(monkeypatch: pytest.MonkeyPatch, patch_templates: dict) -> None:
+    monkeypatch.setattr(routes, "get_files", lambda title, subdir: (["a.svg"], Path(f"/data/{subdir}")))
+    monkeypatch.setattr(routes, "get_temp_title", lambda title: "Title")
+
+    result = routes.by_title_downloaded("topic")
+
+    assert result == "explorer/explore_files.html"
+    context = patch_templates["context"]
+    assert context["files"] == ["a.svg"]
+    assert context["subdir"] == "files"
+    assert context["title"] == "Title"
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_by_title_not_translated():
-    # TODO: Implement test
-    pass
+def test_by_title_translated_sets_compare_link(monkeypatch: pytest.MonkeyPatch, patch_templates: dict) -> None:
+    monkeypatch.setattr(routes, "get_files", lambda title, subdir: (["b.svg"], Path("/data")))
+    monkeypatch.setattr(routes, "get_temp_title", lambda title: "Sample")
+
+    routes.by_title_translated("topic")
+
+    context = patch_templates["context"]
+    assert context["subdir"] == "translated"
+    assert context["compare_link"] is True
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_by_title():
-    # TODO: Implement test
-    pass
+def test_by_title_not_translated_filters(monkeypatch: pytest.MonkeyPatch, patch_templates: dict) -> None:
+    def fake_get_files(title: str, subdir: str):
+        if subdir == "files":
+            return (["one.svg", "two.svg"], Path("/files"))
+        return (["one.svg"], Path("/translated"))
+
+    monkeypatch.setattr(routes, "get_files", fake_get_files)
+    monkeypatch.setattr(routes, "get_temp_title", lambda title: "Topic")
+
+    routes.by_title_not_translated("topic")
+
+    context = patch_templates["context"]
+    assert context["files"] == ["two.svg"]
+    assert context["title"] == "Topic"
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_main():
-    # TODO: Implement test
-    pass
+def test_by_title_renders_information(monkeypatch: pytest.MonkeyPatch, patch_templates: dict) -> None:
+    monkeypatch.setattr(routes, "get_informations", lambda title: {"title": "Topic"})
+
+    routes.by_title("topic")
+
+    assert patch_templates["template"] == "explorer/folder.html"
+    assert patch_templates["context"] == {"result": {"title": "Topic"}}
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_serve_media():
-    # TODO: Implement test
-    pass
+def test_main_lists_titles(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, patch_templates: dict) -> None:
+    root = tmp_path / "data"
+    (root / "alpha").mkdir(parents=True)
+    (root / "beta").mkdir()
+    monkeypatch.setattr(routes, "svg_data_path", root)
+
+    def fake_get_files(title: str, subdir: str):
+        if title == "alpha" and subdir == "files":
+            return (["a.svg"], Path("alpha/files"))
+        if subdir == "translated":
+            return (["a.svg"] if title == "alpha" else [], Path("t"))
+        return ([], Path("empty"))
+
+    monkeypatch.setattr(routes, "get_files", fake_get_files)
+
+    routes.main()
+
+    data = patch_templates["context"]["data"]
+    assert data["alpha"]["downloaded"] == 1
+    assert data["beta"]["translated"] == 0
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_serve_thumb():
-    # TODO: Implement test
-    pass
+def test_serve_media_returns_directory(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[tuple[str, str]] = []
+
+    def fake_send(directory: str, filename: str):
+        called.append((directory, filename))
+        return directory
+
+    monkeypatch.setattr(routes, "svg_data_path", Path("/base"))
+    monkeypatch.setattr(routes, "send_from_directory", fake_send)
+
+    result = routes.serve_media("title", "files", "file.svg")
+
+    assert result == "/base/title/files"
+    assert called == [("/base/title/files", "file.svg")]
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_compare():
-    # TODO: Implement test
-    pass
+def test_serve_thumb_prefers_cached_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    base = tmp_path / "data"
+    thumbs = tmp_path / "thumbs"
+    (base / "topic" / "files").mkdir(parents=True)
+    (thumbs / "topic" / "files").mkdir(parents=True)
+    (base / "topic" / "files" / "file.svg").write_text("<svg/>", encoding="utf-8")
+
+    monkeypatch.setattr(routes, "svg_data_path", base)
+    monkeypatch.setattr(routes, "svg_data_thumb_path", thumbs)
+
+    def fake_save(src: Path, dest: Path) -> None:
+        dest.write_text("thumb", encoding="utf-8")
+        return None
+
+    responses = []
+
+    def fake_send(directory: str, filename: str):
+        responses.append((directory, filename))
+        return directory
+
+    monkeypatch.setattr(routes, "save_thumb", fake_save)
+    monkeypatch.setattr(routes, "send_from_directory", fake_send)
+
+    result = routes.serve_thumb("topic", "files", "file.svg")
+
+    assert result.endswith("files")
+    assert responses[0][0].endswith("thumbs/topic/files")
+
+
+def test_compare_renders_template(monkeypatch: pytest.MonkeyPatch, patch_templates: dict) -> None:
+    monkeypatch.setattr(routes, "svg_data_path", Path("/data"))
+    monkeypatch.setattr(routes, "analyze_file", lambda path: {"file": path.name})
+
+    routes.compare("title", "file.svg")
+
+    context = patch_templates["context"]
+    assert context["downloaded_result"] == {"file": "file.svg"}
+    assert context["translated_result"] == {"file": "file.svg"}

--- a/tests/app/app_routes/explorer/test_thumbnail_utils.py
+++ b/tests/app/app_routes/explorer/test_thumbnail_utils.py
@@ -1,12 +1,14 @@
-"""
-Tests
-"""
-import pytest
+"""Tests for thumbnail utilities."""
 
-from src.app.app_routes.explorer.thumbnail_utils import save_thumb
+from pathlib import Path
+
+from src.app.app_routes.explorer import thumbnail_utils
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_save_thumb():
-    # TODO: Implement test
-    pass
+def test_save_thumb_returns_false(tmp_path: Path) -> None:
+    source = tmp_path / "image.svg"
+    target = tmp_path / "thumb.svg"
+
+    source.write_text("<svg/>", encoding="utf-8")
+
+    assert thumbnail_utils.save_thumb(source, target) is False

--- a/tests/app/app_routes/explorer/test_utils.py
+++ b/tests/app/app_routes/explorer/test_utils.py
@@ -1,42 +1,111 @@
-"""
-Tests
-"""
+"""Tests for explorer utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
 import pytest
 
-from src.app.app_routes.explorer.utils import get_main_data, get_files_full_path, get_files, get_languages, get_temp_title, get_informations
+from src.app.app_routes.explorer import utils
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_main_data():
-    # TODO: Implement test
-    pass
+@pytest.fixture(autouse=True)
+def patch_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    svg_dir = tmp_path / "svg"
+    thumb_dir = tmp_path / "thumbs"
+    svg_dir.mkdir()
+    thumb_dir.mkdir()
+
+    monkeypatch.setattr(utils, "svg_data_path", svg_dir)
+    monkeypatch.setattr(utils, "svg_data_thumb_path", thumb_dir)
+
+    return svg_dir
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_files_full_path():
-    # TODO: Implement test
-    pass
+def test_get_main_data_reads_json(tmp_path: Path) -> None:
+    title_dir = tmp_path / "svg" / "topic"
+    title_dir.mkdir(parents=True)
+    stats = {"main_title": "Main", "values": 1}
+    (title_dir / "files_stats.json").write_text(json.dumps(stats), encoding="utf-8")
+
+    data = utils.get_main_data("topic")
+
+    assert data == stats
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_files():
-    # TODO: Implement test
-    pass
+def test_get_files_full_path_returns_all_files(tmp_path: Path) -> None:
+    title_dir = tmp_path / "svg" / "folder" / "files"
+    title_dir.mkdir(parents=True)
+    (title_dir / "one.svg").write_text("<svg/>", encoding="utf-8")
+    (title_dir / "two.txt").write_text("x", encoding="utf-8")
+
+    files, path = utils.get_files_full_path("folder", "files")
+
+    assert sorted(files) == ["one.svg", "two.txt"]
+    assert path == title_dir
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_languages():
-    # TODO: Implement test
-    pass
+def test_get_files_filters_svg(tmp_path: Path) -> None:
+    title_dir = tmp_path / "svg" / "folder" / "translated"
+    title_dir.mkdir(parents=True)
+    (title_dir / "one.svg").write_text("<svg/>", encoding="utf-8")
+    (title_dir / "two.png").write_text("binary", encoding="utf-8")
+
+    files, _ = utils.get_files("folder", "translated")
+
+    assert files == ["one.svg"]
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_temp_title():
-    # TODO: Implement test
-    pass
+def test_get_languages_extracts_codes() -> None:
+    translations = {
+        "new": {
+            "default_tspans_by_id": {},
+            "section": {"fr": {}, "es": {}},
+            "other": {"de": {}},
+        }
+    }
+
+    langs = utils.get_languages("title", translations)
+
+    assert langs == ["de", "es", "fr"]
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_informations():
-    # TODO: Implement test
-    pass
+def test_get_temp_title_prefers_file(tmp_path: Path) -> None:
+    title_dir = tmp_path / "svg" / "topic"
+    title_dir.mkdir(parents=True)
+    (title_dir / "title.txt").write_text(" Display Title ", encoding="utf-8")
+
+    assert utils.get_temp_title("topic") == "Display Title"
+    assert utils.get_temp_title("missing") == "missing"
+
+
+def test_get_informations_compiles_summary(tmp_path: Path) -> None:
+    base = tmp_path / "svg" / "subject"
+    (base / "files").mkdir(parents=True)
+    (base / "translated").mkdir()
+
+    (base / "files" / "one.svg").write_text("<svg/>", encoding="utf-8")
+    (base / "files" / "two.svg").write_text("<svg/>", encoding="utf-8")
+    (base / "translated" / "one.svg").write_text("<svg/>", encoding="utf-8")
+
+    stats = {
+        "main_title": "Example.svg",
+        "titles": ["File:One.svg", "Other.svg"],
+        "translations": {
+            "new": {
+                "default_tspans_by_id": {},
+                "section": {"es": {}, "it": {}},
+            }
+        },
+    }
+    (base / "files_stats.json").write_text(json.dumps(stats), encoding="utf-8")
+    (base / "title.txt").write_text("Subject", encoding="utf-8")
+
+    info = utils.get_informations("subject")
+
+    assert info["title"] == "Subject"
+    assert info["len_files"]["downloaded"] == 2
+    assert info["len_files"]["translated"] == 1
+    assert info["len_files"]["not_translated"] == 1
+    assert "File:Other.svg" in info["not_downloaded"]

--- a/tests/app/app_routes/tasks/test_args_utils.py
+++ b/tests/app/app_routes/tasks/test_args_utils.py
@@ -1,42 +1,51 @@
-"""Unit tests for args parsing utilities."""
+import types
+
 import pytest
 from werkzeug.datastructures import MultiDict
 
 from src.app.app_routes.tasks import args_utils
 
 
-@pytest.mark.skip(reason="Pending rewrite")
-def test_parse_args_upload_disabled_by_config(monkeypatch):
-    # dataclasses.FrozenInstanceError: cannot assign to field 'disable_uploads'
-    monkeypatch.setattr(args_utils.settings, "disable_uploads", "1")
+def _make_settings(disable_uploads: str) -> types.SimpleNamespace:
+    return types.SimpleNamespace(disable_uploads=disable_uploads)
+
+
+def test_parse_args_upload_disabled_by_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(args_utils, "settings", _make_settings("1"))
     form = MultiDict([("upload", "1")])
+
     parsed = args_utils.parse_args(form)
+
     assert parsed.upload is False
+    assert parsed.ignore_existing_task is False
 
 
-@pytest.mark.skip(reason="Pending rewrite")
-def test_parse_args_manual_main_title_and_limits(monkeypatch):
-    # dataclasses.FrozenInstanceError: cannot assign to field 'disable_uploads'
-    monkeypatch.setattr(args_utils.settings, "disable_uploads", "0")
+def test_parse_args_manual_main_title_and_limits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(args_utils, "settings", _make_settings("0"))
     form = MultiDict(
         [
             ("manual_main_title", "  File:Example name.svg "),
             ("titles_limit", "50"),
             ("overwrite", "z"),
             ("upload", "1"),
+            ("ignore_existing_task", "1"),
         ]
     )
+
     parsed = args_utils.parse_args(form)
+
     assert parsed.manual_main_title == "Example name.svg"
     assert parsed.titles_limit == 50
     assert parsed.overwrite is True
     assert parsed.upload is True
+    assert parsed.ignore_existing_task is True
 
 
-@pytest.mark.skip(reason="Pending rewrite")
-def test_parse_args_empty_manual_main_title(monkeypatch):
-    # dataclasses.FrozenInstanceError: cannot assign to field 'disable_uploads'
-    monkeypatch.setattr(args_utils.settings, "disable_uploads", "0")
+def test_parse_args_empty_manual_main_title(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(args_utils, "settings", _make_settings("0"))
     form = MultiDict([])
+
     parsed = args_utils.parse_args(form)
+
     assert parsed.manual_main_title is None
+    assert parsed.titles_limit == 1000

--- a/tests/app/app_routes/tasks/test_tasks_routes.py
+++ b/tests/app/app_routes/tasks/test_tasks_routes.py
@@ -1,54 +1,355 @@
-"""
-Tests
-"""
+"""Tests for the tasks routes blueprint."""
+
+from __future__ import annotations
+
+import threading
+import types
+import uuid
+from typing import Any
+
 import pytest
+from flask import Flask
 
-from src.app.app_routes.tasks.routes import format_task_message, close_task_store, task, start, status, tasks, delete_task
-
-
-@pytest.mark.skip(reason="Pending write")
-def test_format_task_message():
-    # TODO: Implement test
-    pass
+from src.app import create_app
+from src.app.app_routes.tasks import routes
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_close_task_store():
-    # TODO: Implement test
-    pass
+class DummyTaskStore:
+    """Lightweight in-memory task store used by the tests."""
+
+    def __init__(self) -> None:
+        self.tasks: dict[str, dict[str, Any]] = {}
+        self.closed = False
+
+    def create_task(
+        self,
+        task_id: str,
+        title: str,
+        *,
+        username: str = "",
+        form: dict[str, Any] | None = None,
+    ) -> None:
+        if task_id in self.tasks:
+            raise ValueError(f"Task {task_id} already exists")
+        self.tasks[task_id] = {
+            "id": task_id,
+            "title": title,
+            "username": username,
+            "status": "Pending",
+            "form": dict(form or {}),
+        }
+
+    def get_task(self, task_id: str) -> dict[str, Any] | None:
+        task = self.tasks.get(task_id)
+        return dict(task) if task else None
+
+    def get_active_task_by_title(self, title: str) -> dict[str, Any] | None:
+        for task in self.tasks.values():
+            if task["title"] == title and task.get("status") not in {"Completed", "Failed", "Cancelled"}:
+                return dict(task)
+        return None
+
+    def list_tasks(
+        self,
+        *,
+        username: str | None = None,
+        order_by: str | None = None,
+        descending: bool | None = None,
+    ) -> list[dict[str, Any]]:
+        del order_by
+        del descending
+        tasks = list(self.tasks.values())
+        if username:
+            tasks = [task for task in tasks if task.get("username") == username]
+        return [dict(task) for task in tasks]
+
+    def delete_task(self, task_id: str) -> None:
+        if task_id not in self.tasks:
+            raise LookupError("Task not found")
+        del self.tasks[task_id]
+
+    def close(self) -> None:
+        self.closed = True
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_task():
-    # TODO: Implement test
-    pass
+@pytest.fixture
+def app_client(monkeypatch: pytest.MonkeyPatch) -> tuple[Flask, Any, DummyTaskStore]:
+    """Provide a Flask test client wired with an in-memory task store."""
+
+    monkeypatch.setenv("FLASK_SECRET_KEY", "test-secret-key")
+    app = create_app()
+    app.config["TESTING"] = True
+
+    store = DummyTaskStore()
+
+    def store_factory() -> DummyTaskStore:
+        return store
+
+    monkeypatch.setattr(routes, "_task_store", store_factory)
+    routes.TASK_STORE = store
+    routes.TASKS_LOCK = threading.Lock()
+
+    yield app, app.test_client(), store
+
+    routes.TASK_STORE = None
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_task2():
-    # TODO: Implement test
-    pass
+def test_format_task_message() -> None:
+    formatted = routes.format_task_message(
+        [
+            {
+                "stages": {
+                    "prepare": {"message": "download,convert"},
+                    "upload": {"message": "single"},
+                }
+            },
+            {"stages": {}},
+        ]
+    )
+
+    assert formatted[0]["stages"]["prepare"]["message"] == "download<br>convert"
+    assert formatted[0]["stages"]["upload"]["message"] == "single"
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_start():
-    # TODO: Implement test
-    pass
+def test_close_task_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    store = DummyTaskStore()
+    routes.TASK_STORE = store
+    routes.close_task_store()
+    assert store.closed is True
+
+    routes.TASK_STORE = None
+    # Should be a no-op when the store is already cleared.
+    routes.close_task_store()
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_status():
-    # TODO: Implement test
-    pass
+def test_task_redirects_without_identifier(app_client: tuple[Flask, Any, DummyTaskStore]) -> None:
+    app, client, _ = app_client
+
+    response = client.get("/task")
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/")
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_tasks():
-    # TODO: Implement test
-    pass
+def test_task_renders_context_with_missing_task(
+    app_client: tuple[Flask, Any, DummyTaskStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, _, store = app_client
+    store.tasks.clear()
+
+    captured: dict[str, Any] = {}
+    flashed: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(routes, "current_user", lambda: None)
+
+    def fake_render(template: str, **context: Any) -> str:
+        captured["template"] = template
+        captured["context"] = context
+        return "rendered"
+
+    def fake_flash(message: str, category: str) -> None:
+        flashed.append((message, category))
+
+    monkeypatch.setattr(routes, "render_template", fake_render)
+    monkeypatch.setattr(routes, "flash", fake_flash)
+
+    with app.test_request_context("/task/missing?title=Sample&error=task-active"):
+        result = routes.task("missing")
+
+    assert result == "rendered"
+    assert captured["template"] == "task.html"
+    assert captured["context"]["task"]["error"] == "not-found"
+    assert captured["context"]["title"] == "Sample"
+    assert flashed == [("A task for this title is already in progress.", "warning")]
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_delete_task():
-    # TODO: Implement test
-    pass
+def test_task2_includes_ordered_stages(
+    app_client: tuple[Flask, Any, DummyTaskStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, _, store = app_client
+    store.tasks["task42"] = {
+        "id": "task42",
+        "title": "Example",
+        "stages": {
+            "convert": {"number": 2, "message": "convert"},
+            "download": {"number": 1, "message": "download"},
+        },
+        "form": {"field": "value"},
+    }
+
+    monkeypatch.setattr(routes, "current_user", lambda: types.SimpleNamespace(username="demo"))
+
+    captured: dict[str, Any] = {}
+
+    def fake_render(template: str, **context: Any) -> str:
+        captured["template"] = template
+        captured["context"] = context
+        return "rendered"
+
+    monkeypatch.setattr(routes, "render_template", fake_render)
+
+    with app.test_request_context("/task2/task42"):
+        result = routes.task2("task42")
+
+    assert result == "rendered"
+    assert captured["template"] == "task2.html"
+    assert [name for name, _ in captured["context"]["stages"]] == ["download", "convert"]
+    assert captured["context"]["task"]["id"] == "task42"
+
+
+def test_start_creates_task_and_launches_thread(
+    app_client: tuple[Flask, Any, DummyTaskStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, client, store = app_client
+
+    user = types.SimpleNamespace(
+        username="tester",
+        access_token="token",
+        access_secret="secret",
+        user_id=1,
+    )
+
+    monkeypatch.setattr(routes, "current_user", lambda: user)
+    monkeypatch.setattr("src.app.users.current.current_user", lambda: user)
+
+    generated_id = "abc123"
+    monkeypatch.setattr(uuid, "uuid4", lambda: types.SimpleNamespace(hex=generated_id))
+
+    launch_calls: list[tuple[Any, ...]] = []
+
+    def fake_launch(task_id: str, title: str, args: Any, auth_payload: dict[str, Any]) -> None:
+        launch_calls.append((task_id, title, args, auth_payload))
+
+    monkeypatch.setattr(routes, "launch_task_thread", fake_launch)
+
+    response = client.post("/", data={"title": "Sample Title", "upload": "on"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(f"/task/{generated_id}?title=Sample+Title")
+    assert generated_id in store.tasks
+    assert store.tasks[generated_id]["title"] == "Sample Title"
+    assert launch_calls and launch_calls[0][0] == generated_id
+    assert launch_calls[0][1] == "Sample Title"
+    assert launch_calls[0][3]["username"] == "tester"
+
+
+def test_start_redirects_to_existing_task_when_duplicate(
+    app_client: tuple[Flask, Any, DummyTaskStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, client, store = app_client
+
+    user = types.SimpleNamespace(
+        username="tester",
+        access_token="token",
+        access_secret="secret",
+        user_id=1,
+    )
+
+    monkeypatch.setattr(routes, "current_user", lambda: user)
+    monkeypatch.setattr("src.app.users.current.current_user", lambda: user)
+
+    existing_id = "existing"
+    store.create_task(existing_id, "Duplicate Title", username="tester", form={"title": "Duplicate Title"})
+
+    flashed: list[tuple[str, str]] = []
+
+    def fake_flash(message: str, category: str) -> None:
+        flashed.append((message, category))
+
+    monkeypatch.setattr(routes, "flash", fake_flash)
+
+    launch_calls: list[tuple[Any, ...]] = []
+    monkeypatch.setattr(routes, "launch_task_thread", lambda *args, **kwargs: launch_calls.append(args))
+
+    response = client.post("/", data={"title": "Duplicate Title"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(f"/task/{existing_id}?title=Duplicate+Title")
+    assert flashed == [("Task for title 'Duplicate Title' already exists: existing.", "warning")]
+    assert not launch_calls
+
+
+def test_status_returns_task_payload(
+    app_client: tuple[Flask, Any, DummyTaskStore]
+) -> None:
+    app, client, store = app_client
+
+    store.tasks["task1"] = {"id": "task1", "status": "Pending"}
+
+    missing = client.get("/status/missing")
+    assert missing.status_code == 404
+    assert missing.get_json() == {"error": "not-found"}
+
+    response = client.get("/status/task1")
+    assert response.status_code == 200
+    assert response.get_json() == {"id": "task1", "status": "Pending"}
+
+
+def test_tasks_renders_formatted_tasks(
+    app_client: tuple[Flask, Any, DummyTaskStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, client, store = app_client
+
+    store.tasks["t1"] = {"id": "t1", "status": "Queued", "username": "alice"}
+    store.tasks["t2"] = {"id": "t2", "status": "Completed", "username": "alice"}
+
+    user = types.SimpleNamespace(username="alice")
+    monkeypatch.setattr(routes, "current_user", lambda: user)
+
+    formatted_inputs: list[list[dict[str, Any]]] = []
+
+    def fake_format_task(task: dict[str, Any]) -> dict[str, Any]:
+        return {"id": task["id"], "status": task.get("status")}
+
+    def fake_format_message(values: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        formatted_inputs.append(values)
+        return [{"id": item["id"], "status": item["status"], "processed": True} for item in values]
+
+    captured: dict[str, Any] = {}
+
+    def fake_render(template: str, **context: Any) -> str:
+        captured["template"] = template
+        captured["context"] = context
+        return "rendered"
+
+    monkeypatch.setattr(routes, "format_task", fake_format_task)
+    monkeypatch.setattr(routes, "format_task_message", fake_format_message)
+    monkeypatch.setattr(routes, "render_template", fake_render)
+
+    response = client.get("/tasks/alice")
+
+    assert response.status_code == 200
+    assert response.data == b"rendered"
+    assert captured["template"] == "tasks.html"
+    assert captured["context"]["tasks"] == [
+        {"id": "t1", "status": "Queued", "processed": True},
+        {"id": "t2", "status": "Completed", "processed": True},
+    ]
+    assert captured["context"]["available_statuses"] == ["Completed", "Queued"]
+    assert captured["context"]["is_own_tasks"] is True
+    assert formatted_inputs and len(formatted_inputs[0]) == 2
+
+
+def test_delete_task_success(
+    app_client: tuple[Flask, Any, DummyTaskStore], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, client, store = app_client
+
+    store.tasks["deadbeef"] = {"id": "deadbeef", "title": "Delete me"}
+
+    user = types.SimpleNamespace(username="admin")
+    monkeypatch.setattr("src.app.app_routes.admin.admins_required.current_user", lambda: user)
+    monkeypatch.setattr("src.app.app_routes.admin.admins_required.active_coordinators", lambda: ["admin"])
+
+    flashed: list[tuple[str, str]] = []
+
+    def fake_flash(message: str, category: str) -> None:
+        flashed.append((message, category))
+
+    monkeypatch.setattr(routes, "flash", fake_flash)
+
+    response = client.post("/task/deadbeef/delete")
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/tasks")
+    assert "deadbeef" not in store.tasks
+    assert flashed == [("Task 'deadbeef' removed.", "success")]

--- a/tests/app/app_routes/templates/test_category.py
+++ b/tests/app/app_routes/templates/test_category.py
@@ -1,24 +1,71 @@
-"""
-Tests
-"""
+"""Tests for category helpers."""
+
+from __future__ import annotations
+
+import json
+import types
+
 import pytest
 
-from src.app.app_routes.templates.category import get_category_members_api, get_category_members_petscan, get_category_members
+from src.app.app_routes.templates import category
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_category_members_api():
-    # TODO: Implement test
-    pass
+@pytest.fixture(autouse=True)
+def patch_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(category, "settings", types.SimpleNamespace(oauth=types.SimpleNamespace(user_agent="agent")))
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_category_members_petscan():
-    # TODO: Implement test
-    pass
+def test_get_category_members_api_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyResponse:
+        def __init__(self, pages):
+            self._pages = pages
+            self.status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return self._pages
+
+    class DummySession:
+        def __init__(self) -> None:
+            self.headers = {}
+            self.calls = []
+
+        def get(self, url, params=None, timeout=None):
+            self.calls.append((url, params, timeout))
+            if "cmcontinue" in params:
+                return DummyResponse({"query": {"categorymembers": []}})
+            return DummyResponse({
+                "continue": {"cmcontinue": "next"},
+                "query": {"categorymembers": [{"title": "Page"}]},
+            })
+
+    monkeypatch.setattr(category.requests, "Session", DummySession)
+
+    pages = category.get_category_members_api("Category:Example", "commons.wikimedia.org")
+
+    assert pages == ["Page"]
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_category_members():
-    # TODO: Implement test
-    pass
+def test_get_category_members_petscan(monkeypatch: pytest.MonkeyPatch) -> None:
+    class DummyResponse:
+        text = "Page\nAnother"
+
+        def raise_for_status(self) -> None:
+            return None
+
+    monkeypatch.setattr(category.requests, "get", lambda url, headers=None, timeout=None: DummyResponse())
+
+    pages = category.get_category_members_petscan("Category:Example", "commons.wikimedia.org")
+
+    assert pages == ["Page", "Another"]
+
+
+def test_get_category_members_prefers_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(category, "get_category_members_api", lambda *args, **kwargs: ["Page1"])
+    monkeypatch.setattr(category, "get_category_members_petscan", lambda *args, **kwargs: ["Page2"])
+
+    pages = category.get_category_members()
+
+    assert pages == ["Page1"]

--- a/tests/app/app_routes/templates/test_templates_routes.py
+++ b/tests/app/app_routes/templates/test_templates_routes.py
@@ -1,24 +1,48 @@
-"""
-Tests
-"""
+"""Tests for templates routes utilities."""
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
 import pytest
 
-from src.app.app_routes.templates.routes import get_main_data, temp_data, temps_main_files
+from src.app.app_routes.templates import routes
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_get_main_data():
-    # TODO: Implement test
-    pass
+@pytest.fixture(autouse=True)
+def patch_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    svg_dir = tmp_path / "svg"
+    svg_dir.mkdir()
+    monkeypatch.setattr(routes, "settings", types.SimpleNamespace(paths=types.SimpleNamespace(svg_data=str(svg_dir))))
+    return svg_dir
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_temp_data():
-    # TODO: Implement test
-    pass
+def test_get_main_data_reads_file(tmp_path: Path) -> None:
+    title_dir = tmp_path / "svg" / "topic"
+    title_dir.mkdir(parents=True)
+    payload = {"value": 1}
+    (title_dir / "files_stats.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    assert routes.get_main_data("topic") == payload
 
 
-@pytest.mark.skip(reason="Pending write")
-def test_temps_main_files():
-    # TODO: Implement test
-    pass
+def test_temp_data_sanitizes_name(tmp_path: Path) -> None:
+    sanitized = "template_clean_name"
+    (tmp_path / "svg" / sanitized).mkdir(parents=True)
+
+    result = routes.temp_data("Template:Clean Name!")
+
+    assert result["title_dir"] == sanitized
+
+
+def test_temps_main_files_falls_back_to_main_data(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    template_entry = {"Sample": {"title_dir": "sample"}}
+    monkeypatch.setattr(routes, "get_templates_db", lambda: types.SimpleNamespace(list=lambda: []))
+    monkeypatch.setattr(routes, "add_or_update_template", lambda title, main_file: None)
+    monkeypatch.setattr(routes, "get_main_data", lambda title: {"main_title": "Example.svg"})
+
+    data = routes.temps_main_files(template_entry)
+
+    assert data["Sample"]["main_file"] == "File:Example.svg"


### PR DESCRIPTION
## Summary
- implement pytest coverage for explorer, auth, admin, templates, and cancel/restart blueprints
- provide deterministic fixtures and monkeypatches to isolate filesystem, network, and OAuth dependencies
- exercise args parsing, cookie helpers, and compare utilities with realistic data sets

## Testing
- pytest tests/app/app_routes

------
https://chatgpt.com/codex/tasks/task_e_690c3f96e8948322a43db227601779a5