### PR TITLE
Fix SQLAlchemy database services bugs

### DIFF
--- a/src/main_app/sqlalchemy_db/models/owid_charts.py
+++ b/src/main_app/sqlalchemy_db/models/owid_charts.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import Boolean, Column, DateTime, Index, Integer, String, func
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String, func
+from sqlalchemy.orm import relationship
 
 from ..engine import BaseDb
 
@@ -45,6 +46,22 @@ class OwidChartRecord(BaseDb):
     single_year_data = Column(Boolean, server_default="0")
     len_years = Column(Integer, nullable=True)
     has_timeline = Column(Boolean, server_default="0")
+
+    _template_info = relationship(
+        "OwidChartTemplateRecord",
+        primaryjoin="OwidChartRecord.chart_id == OwidChartTemplateRecord.chart_id",
+        foreign_keys="OwidChartTemplateRecord.chart_id",
+        viewonly=True,
+        uselist=False,
+    )
+
+    @property
+    def template_id(self) -> int | None:
+        return self._template_info.template_id if hasattr(self, "_template_info") and self._template_info else None
+
+    @property
+    def template_title(self) -> str | None:
+        return self._template_info.template_title if hasattr(self, "_template_info") and self._template_info else None
 
     created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())
     updated_at = Column(

--- a/src/main_app/sqlalchemy_db/services/admin_service.py
+++ b/src/main_app/sqlalchemy_db/services/admin_service.py
@@ -58,6 +58,8 @@ def set_coordinator_active(coordinator_id: int, is_active: bool) -> AdminUserRec
     with get_session() as session:
         # record = get_coordinator_by_id(coordinator_id)
         record = session.query(AdminUserRecord).filter(AdminUserRecord.id == coordinator_id).first()
+        if not record:
+            raise LookupError(f"Coordinator id {coordinator_id} was not found")
 
         record.is_active = is_active
         session.commit()

--- a/src/main_app/sqlalchemy_db/services/jobs_service.py
+++ b/src/main_app/sqlalchemy_db/services/jobs_service.py
@@ -96,7 +96,7 @@ def update_job_status(job_id: int, status: str, result_file: str | None = None, 
 
     """
     if status == "running":
-        return update_running_status(job_id, result_file, job_type)
+        return update_running_status(job_id, result_file, job_type=job_type)
 
     return _update_status(job_id, status, result_file, job_type)
 
@@ -121,7 +121,7 @@ def list_jobs(limit: int = 100, job_type: str | None = None) -> list[JobRecord]:
     with get_session() as session:
         query = session.query(JobRecord)
         if job_type:
-            query.filter(JobRecord.job_type == job_type)
+            query = query.filter(JobRecord.job_type == job_type)
         return query.order_by(JobRecord.created_at.desc()).limit(limit).all()
 
 
@@ -155,14 +155,11 @@ def cancel_job(job_id: int, job_type: str | None = None) -> bool:
         return rowcount > 0
     """
     with get_session() as session:
-        job = (
-            session.query(JobRecord)
-            .filter(
-                JobRecord.id == job_id,
-                JobRecord.job_type == job_type,
-            )
-            .first()
-        )
+        query = session.query(JobRecord).filter(JobRecord.id == job_id)
+        if job_type:
+            query = query.filter(JobRecord.job_type == job_type)
+
+        job = query.filter(JobRecord.status.in_(["pending", "running"])).first()
 
         if job:
             job.status = "cancelled"

--- a/src/main_app/sqlalchemy_db/services/owid_charts_service.py
+++ b/src/main_app/sqlalchemy_db/services/owid_charts_service.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import logging
 from typing import Any, List, Optional
 
+from sqlalchemy.orm import joinedload
+
 from ..engine import get_session
 from ..models.owid_charts import OwidChartRecord
+from ..models.views import OwidChartTemplateRecord
 
 logger = logging.getLogger(__name__)
 
 
-def list_charts(limit: int = 100) -> List[OwidChartRecord]:
+def list_charts(limit: int | None = None) -> List[OwidChartRecord]:
     """
     Return all charts from the view.
 
@@ -19,7 +22,10 @@ def list_charts(limit: int = 100) -> List[OwidChartRecord]:
         ORDER BY oc.chart_id ASC
     """
     with get_session() as session:
-        return session.query(OwidChartRecord).limit(limit).all()
+        query = session.query(OwidChartRecord).options(joinedload(OwidChartRecord._template_info))
+        if limit:
+            query = query.limit(limit)
+        return query.all()
 
 
 def list_published_charts() -> List[OwidChartRecord]:
@@ -33,7 +39,12 @@ def list_published_charts() -> List[OwidChartRecord]:
         ORDER BY oc.chart_id ASC
     """
     with get_session() as session:
-        return session.query(OwidChartRecord).filter(OwidChartRecord.is_published == 1)
+        return (
+            session.query(OwidChartRecord)
+            .filter(OwidChartRecord.is_published == 1)
+            .options(joinedload(OwidChartRecord._template_info))
+            .all()
+        )
 
 
 def get_chart_by_id(chart_id: int) -> OwidChartRecord:
@@ -46,7 +57,12 @@ def get_chart_by_id(chart_id: int) -> OwidChartRecord:
         and oct.chart_id = oc.chart_id
     """
     with get_session() as session:
-        return session.query(OwidChartRecord).filter(OwidChartRecord.chart_id == chart_id).first()
+        return (
+            session.query(OwidChartRecord)
+            .filter(OwidChartRecord.chart_id == chart_id)
+            .options(joinedload(OwidChartRecord._template_info))
+            .first()
+        )
 
 
 def get_chart_by_slug(slug: str) -> Optional[OwidChartRecord]:
@@ -59,7 +75,12 @@ def get_chart_by_slug(slug: str) -> Optional[OwidChartRecord]:
         and oct.chart_id = oc.chart_id
     """
     with get_session() as session:
-        return session.query(OwidChartRecord).filter(OwidChartRecord.slug == slug).first()
+        return (
+            session.query(OwidChartRecord)
+            .filter(OwidChartRecord.slug == slug)
+            .options(joinedload(OwidChartRecord._template_info))
+            .first()
+        )
 
 
 def add_chart(
@@ -95,7 +116,7 @@ def update_chart_data(
         chart = session.query(OwidChartRecord).filter(OwidChartRecord.chart_id == chart_id).first()
         if chart:
             for key, value in chart_data.items():
-                if value:
+                if value is not None:
                     setattr(chart, key, value)
         session.commit()
         session.refresh(chart)

--- a/src/main_app/sqlalchemy_db/services/owid_charts_service.py
+++ b/src/main_app/sqlalchemy_db/services/owid_charts_service.py
@@ -22,8 +22,8 @@ def list_charts(limit: int | None = None) -> List[OwidChartRecord]:
         ORDER BY oc.chart_id ASC
     """
     with get_session() as session:
-        query = session.query(OwidChartRecord).options(joinedload(OwidChartRecord._template_info))
-        if limit:
+        query = session.query(OwidChartRecord).options(joinedload(OwidChartRecord._template_info)).order_by(OwidChartRecord.chart_id.asc())
+        if limit is not None:
             query = query.limit(limit)
         return query.all()
 

--- a/src/main_app/sqlalchemy_db/services/owid_charts_service.py
+++ b/src/main_app/sqlalchemy_db/services/owid_charts_service.py
@@ -43,6 +43,7 @@ def list_published_charts() -> List[OwidChartRecord]:
             session.query(OwidChartRecord)
             .filter(OwidChartRecord.is_published == 1)
             .options(joinedload(OwidChartRecord._template_info))
+            .order_by(OwidChartRecord.chart_id.asc())
             .all()
         )
 

--- a/src/main_app/sqlalchemy_db/services/settings_service.py
+++ b/src/main_app/sqlalchemy_db/services/settings_service.py
@@ -10,7 +10,7 @@ from ..models.settings import SettingRecord
 logger = logging.getLogger(__name__)
 
 
-def _parse_setting_value(v_type: str, raw_val: str) -> tuple[any, bool]:
+def _parse_setting_value(v_type: str, raw_val: str) -> tuple[Any, bool]:
     """Returns (value, success)"""
     if v_type == "boolean":
         return raw_val == "on", True
@@ -26,6 +26,21 @@ def _parse_setting_value(v_type: str, raw_val: str) -> tuple[any, bool]:
             return None, False
     else:
         return raw_val, True
+
+
+def _serialize_value(value: Any, value_type: str) -> str | None:
+    if value is None:
+        return None
+    if value_type == "boolean":
+        return "true" if value else "false"
+    elif value_type == "integer":
+        try:
+            return str(int(value))
+        except (ValueError, TypeError):
+            return "0"
+    elif value_type == "json":
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
 
 
 def list_settings() -> list[SettingRecord]:
@@ -59,45 +74,48 @@ def delete_setting(key: str) -> bool:
 def update_setting(
     key: str,
     value: Any,
-    value_type: str = "string",
+    value_type: str | None = None,
     title: str | None = None,
-) -> SettingRecord:
+) -> bool:
     """
     Update an existing setting.
     """
     with get_session() as session:
         setting = session.query(SettingRecord).filter(SettingRecord.key == key).first()
-        if setting:
-            setting.value = str(value)
-            if title:
-                setting.title = title
-        else:
-            setting = SettingRecord(key=key, value=str(value), title=title or key, value_type=value_type)
-            session.add(setting)
+        if not setting:
+            return False
+
+        if not value_type:
+            value_type = setting.value_type
+
+        setting.value = _serialize_value(value, value_type)
+        if title:
+            setting.title = title
         session.commit()
-        session.refresh(setting)
-        return setting
+        return True
 
 
 def create_setting(key: str, title: str, value_type: str) -> bool:
     """
     Create new setting.
     """
-    if value_type == "boolean":
-        value = False
-    elif value_type == "integer":
-        value = 0
-    elif value_type == "json":
-        value = {}
-    else:
-        value = ""
+    default_value_types = {
+        "boolean": "false",
+        "integer": "0",
+        "json": "{}",
+    }
+
+    value = default_value_types.get(value_type, "")
 
     with get_session() as session:
-        job = SettingRecord(key=key, title=title, value=value, value_type=value_type)
-        session.add(job)
-        session.commit()
-        session.refresh(job)
-        return job
+        setting = SettingRecord(key=key, title=title, value=value, value_type=value_type)
+        session.add(setting)
+        try:
+            session.commit()
+            return True
+        except Exception:
+            session.rollback()
+            return False
 
 
 def settings_update_form(request_form) -> tuple[list[str], list[str]]:

--- a/src/main_app/sqlalchemy_db/services/template_service.py
+++ b/src/main_app/sqlalchemy_db/services/template_service.py
@@ -25,7 +25,7 @@ def list_templates(limit: int | None = None) -> List[TemplateRecord]:
     with get_session() as session:
         query = session.query(TemplateRecord).order_by(TemplateRecord.title)
         if limit:
-            query.limit(limit)
+            query = query.limit(limit)
         return query.all()
 
 
@@ -68,7 +68,7 @@ def update_template_data(
         template = session.query(TemplateRecord).filter(TemplateRecord.id == template_id).first()
         if template:
             for key, value in template_data.items():
-                if value:
+                if value is not None:
                     setattr(template, key, value)
             session.commit()
             session.refresh(template)

--- a/src/main_app/sqlalchemy_db/services/user_token_service.py
+++ b/src/main_app/sqlalchemy_db/services/user_token_service.py
@@ -18,9 +18,7 @@ logger = logging.getLogger(__name__)
 
 def upsert_user_token(*, user_id: int, username: str, access_key: str, access_secret: str) -> None:
     """Insert or update the encrypted OAuth credentials for a user."""
-    username = username.strip()
-    if not username:
-        raise ValueError("Username is required")
+    username = (username or "").strip()
 
     encrypted_token = encrypt_value(access_key)
     encrypted_secret = encrypt_value(access_secret)
@@ -44,6 +42,7 @@ def upsert_user_token(*, user_id: int, username: str, access_key: str, access_se
                 created_at=now,
                 updated_at=now,
                 last_used_at=now,
+                rotated_at=None,
             )
             session.add(orm_obj)
 


### PR DESCRIPTION
I have completed the task of fixing all the bugs and differences listed in `plans/db_vs_sqlalchemy_services_findings.md`. 

Key changes include:
1.  **Jobs Service**: Fixed `TypeError` in `update_job_status`, corrected `list_jobs` filtering, and added a status guard to `cancel_job`.
2.  **OWID Charts Service**: Added `.all()` to `list_published_charts`, removed the hard-cap on `list_charts`, allowed falsy values in updates, and restored template metadata availability via ORM relationships.
3.  **Settings Service**: Updated `create_setting` to return a boolean and handle duplicates, implemented proper type serialization in `update_setting`, and disabled silent upserts.
4.  **Template Service**: Fixed `list_templates` limit application and allowed falsy values in updates.
5.  **Admin Service**: Added proper error handling (LookupError) when coordinators are not found.
6.  **User Token Service**: Relaxed username validation and fixed `rotated_at` timestamp logic.

All changes were verified with targeted unit tests for the SQLAlchemy services and by running the existing test suite.

---
*PR created automatically by Jules for task [16158043286789401453](https://jules.google.com/task/16158043286789401453) started by @MrIbrahem*