### PR TITLE
Add background job to capitalize OWID subpage names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,10 @@ REQUEST_TOKEN_SESSION_KEY=state
 STATE_SESSION_KEY=oauth_state
 
 DEV_DOWNLOAD_LIMIT=10
+
+# Credentials used by offline maintenance scripts in _works_files/
+# (e.g. rename_owid_pages.py). Generate at:
+#   https://commons.wikimedia.org/wiki/Special:BotPasswords
+# Use the "User@Botname" form for WIKI_USERNAME.
+WIKI_USERNAME=
+WIKI_PASSWORD=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,14 +142,53 @@ src/
     __init__.py          # Flask app factory
     config.py            # Settings dataclasses
     app_routes/          # Flask blueprints
+      admin/             # Admin panel (sidebar, routes, auth)
+      admin_routes/      # Admin sub-routes (coordinators, jobs, etc.)
+      auth/              # OAuth authentication
+      main_routes/       # Public routes
     api_services/        # MediaWiki API clients
-    db/                  # Database layer
-    tasks/               # Task pipeline stages
-    threads/             # Background task execution
+      clients/           # mwclient site builders (wiki_client, commons_client)
+      mwclient_page.py   # MwClientPage class (edit, move, redirect check with retry)
+      pages_api.py       # Thin wrappers: is_page_exists, is_redirect, edit_page, move_page
+      text_api.py        # Fetch page/file wikitext
+      category.py        # Category member listing
+    sqlalchemy_db/       # SQLAlchemy models & services
+    jobs_workers/        # Background job workers (BaseJobWorker pattern)
+      base_worker.py     # Abstract base with lifecycle, retry, cancellation
+      workers_list.py    # Job registry (jobs_targets, JOB_TYPE_TEMPLATES)
+      create_owid_pages/ # Create OWID gallery pages from templates
+      rename_owid_pages/ # Capitalize OWID subpage first letter (move/redirect)
+      crop_main_files/   # Crop newest world files
     utils/               # Helper utilities
+  templates/             # Jinja2 templates
+    admins/jobs_templates/  # Job-specific detail/list templates
   app.py                 # WSGI entry point
 tests/                   # Test files (mirror src structure)
+_works_files/            # Offline CLI tools (not part of Flask app)
+  rename_owid_pages.py   # Standalone OWID rename script (uses .env credentials)
 ```
+
+## Background Jobs
+
+### Adding a New Job
+
+1. Create `src/main_app/jobs_workers/<job_name>/worker.py` with a class extending `BaseJobWorker`
+2. Implement: `get_job_type()`, `get_initial_result()`, `process()`
+3. Create `__init__.py` exporting the entry-point function
+4. Register in `workers_list.py`: add to `jobs_targets`, `JOB_TYPE_TEMPLATES`, `JOB_TYPE_LIST_TEMPLATES`
+5. Add sidebar item in `app_routes/admin/sidebar.py`
+6. Create templates: `src/templates/admins/jobs_templates/<job_name>/list.html` and `details.html`
+
+### MwClientPage Pattern
+
+All mwclient operations go through `MwClientPage` which provides:
+- `load_page()` — load page object, cache it
+- `check_exists()` — check page existence
+- `is_redirect()` — check if page is redirect using `page.redirects_to()`
+- `edit_page(text, summary)` — edit with rate-limit retry
+- `move_page(new_title, reason, ...)` — move/rename with rate-limit retry
+
+Rate-limit retry: on `ratelimited` error, retries after 5s, 15s, 30s delays.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,44 @@ DISABLE_UPLOADS=0           # Set to 1 to disable uploads
 DEV_DOWNLOAD_LIMIT=10       # Limit downloads in dev (0 = unlimited)
 ```
 
+### Background Jobs (Admin)
+
+Background jobs are registered in `src/main_app/jobs_workers/workers_list.py` and use `BaseJobWorker` (`src/main_app/jobs_workers/base_worker.py`) for lifecycle management.
+
+| Job Type                    | Worker Location                                         | Purpose                                                  |
+| --------------------------- | ------------------------------------------------------- | -------------------------------------------------------- |
+| `collect_main_files`        | `jobs_workers/collect_main_files_worker.py`             | Collect template metadata from Commons                   |
+| `crop_main_files`           | `jobs_workers/crop_main_files/`                         | Crop newest world files                                  |
+| `create_owid_pages`         | `jobs_workers/create_owid_pages/`                       | Create OWID gallery pages from templates                 |
+| `rename_owid_pages`         | `jobs_workers/rename_owid_pages/`                       | Capitalize first letter of OWID subpage names            |
+| `add_svglanguages_template` | `jobs_workers/add_svglanguages_template/`               | Add {{SVGLanguages}} template to files                   |
+| `fix_nested_main_files`     | `jobs_workers/fix_nested_main_files_worker.py`          | Fix nested SVG file structures                           |
+| `download_main_files`       | `jobs_workers/download_main_files_worker.py`            | Download main files from Commons                         |
+
+Jobs use the current user's OAuth session (via `get_user_site(user)`) for wiki operations.
+
+### MediaWiki Page Operations (`api_services/pages_api.py`)
+
+All wiki page operations go through `MwClientPage` (`api_services/mwclient_page.py`) which handles:
+- Page loading, existence checks, redirect detection
+- Editing with rate-limit retry (5s, 15s, 30s delays)
+- Moving (renaming) with rate-limit retry
+
+Thin wrappers in `pages_api.py`:
+
+```python
+is_page_exists(title, site)   # Check if page exists
+is_redirect(title, site)      # Check if page is a redirect (uses page.redirects_to())
+edit_page(site, title, text, summary)  # Edit page content
+move_page(site, title, new_title, reason, ...)  # Move/rename page
+```
+
+### Offline Tools (`_works_files/`)
+
+Standalone CLI scripts not part of the Flask app:
+
+- **`rename_owid_pages.py`** — Capitalize OWID subpage names using WIKI_USERNAME/WIKI_PASSWORD from `.env`. Dry-run by default; use `--apply` to execute.
+
 ### External Dependencies
 
 -   **CopySVGTranslation**: Core SVG translation library (external package)

--- a/_works_files/rename_owid_pages.py
+++ b/_works_files/rename_owid_pages.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+"""Offline tool to capitalize the first letter of OWID subpages on Wikimedia Commons.
+
+Lists every page whose title starts with ``Template:OWID/`` or ``OWID/`` and
+renames it so that the character immediately after ``OWID/`` is uppercase.
+
+Examples
+--------
+    Template:OWID/daily_meat_consumption_per_person
+        -> Template:OWID/Daily_meat_consumption_per_person
+
+    OWID/daily_meat_consumption_per_person
+        -> OWID/Daily_meat_consumption_per_person
+
+Usage
+-----
+    # List candidates only (safe, no changes):
+    python _works_files/rename_owid_pages.py
+
+    # Actually perform the renames:
+    python _works_files/rename_owid_pages.py --apply
+
+    # Don't leave a redirect at the old title (needs suppressredirect right):
+    python _works_files/rename_owid_pages.py --apply --no-redirect
+
+Credentials
+-----------
+Reads ``WIKI_USERNAME`` and ``WIKI_PASSWORD`` from ``.env`` at the repo root.
+For Wikimedia projects you should generate a Bot Password at
+https://commons.wikimedia.org/wiki/Special:BotPasswords and use the
+``User@Botname`` form for ``WIKI_USERNAME``.
+
+This script is intentionally NOT wired into the Flask app; run it as a
+standalone command-line tool.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import mwclient
+import mwclient.errors
+from dotenv import load_dotenv
+
+logger = logging.getLogger("rename_owid_pages")
+
+# (namespace_id, prefix_without_namespace, full_prefix_label_for_display)
+PREFIXES: tuple[tuple[int, str, str], ...] = (
+    (10, "OWID/", "Template:OWID/"),  # Template namespace
+    (0, "OWID/", "OWID/"),  # Main namespace
+)
+
+
+def setup_logging(verbose: bool = False) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+
+def load_credentials() -> tuple[str, str]:
+    """Load ``WIKI_USERNAME`` and ``WIKI_PASSWORD`` from ``.env``."""
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if env_path.exists():
+        load_dotenv(env_path)
+        logger.debug("Loaded environment from %s", env_path)
+    else:
+        logger.warning("No .env file at %s; relying on process environment", env_path)
+
+    username = (os.getenv("WIKI_USERNAME") or "").strip()
+    password = (os.getenv("WIKI_PASSWORD") or "").strip()
+
+    if not username or not password:
+        logger.error("WIKI_USERNAME and WIKI_PASSWORD must be set in .env or environment")
+        sys.exit(2)
+    return username, password
+
+
+def build_site(host: str, user_agent: str, username: str, password: str) -> mwclient.Site:
+    """Create an authenticated mwclient.Site using BotPassword/login."""
+    logger.info("Connecting to %s as %s", host, username)
+    site = mwclient.Site(host, scheme="https", clients_useragent=user_agent)
+    site.login(username, password)
+    logger.info("Logged in successfully")
+    return site
+
+
+def needs_rename(title: str, full_prefix: str) -> tuple[bool, str]:
+    """Decide whether *title* needs a rename.
+
+    Returns ``(needs_rename, new_title)``. Only the first character after
+    ``full_prefix`` is changed; all other characters (including spaces /
+    underscores and the rest of the path) are preserved as-is.
+    """
+    if not title.startswith(full_prefix):
+        return False, title
+    rest = title[len(full_prefix):]
+    if not rest:
+        return False, title
+    first = rest[0]
+    if first.isalpha() and first.islower():
+        return True, full_prefix + first.upper() + rest[1:]
+    return False, title
+
+
+def iter_owid_pages(site: mwclient.Site, namespace: int, prefix: str) -> Iterable:
+    """Yield non-redirect pages with the given prefix in *namespace*."""
+    # filterredir='nonredirects' avoids picking up redirects that previous
+    # runs of this script may have left behind.
+    return site.allpages(prefix=prefix, namespace=namespace, filterredir="nonredirects")
+
+
+def process(
+    site: mwclient.Site,
+    apply: bool,
+    reason: str,
+    move_talk: bool,
+    no_redirect: bool,
+) -> dict[str, int]:
+    stats = {
+        "checked": 0,
+        "to_rename": 0,
+        "renamed": 0,
+        "skipped_exists": 0,
+        "failed": 0,
+    }
+
+    for namespace, prefix, full_prefix in PREFIXES:
+        logger.info("Listing pages with prefix %r (namespace %d)", full_prefix, namespace)
+        ns_count = 0
+        for page in iter_owid_pages(site, namespace, prefix):
+            stats["checked"] += 1
+            ns_count += 1
+            title = page.name
+            yes, new_title = needs_rename(title, full_prefix)
+            if not yes:
+                logger.debug("  ok: %s", title)
+                continue
+
+            stats["to_rename"] += 1
+            logger.info("  RENAME: %s -> %s", title, new_title)
+            if not apply:
+                continue
+
+            target = site.pages[new_title]
+            if target.exists:
+                logger.warning("  SKIP (target already exists): %s", new_title)
+                stats["skipped_exists"] += 1
+                continue
+
+            try:
+                page.move(
+                    new_title,
+                    reason=reason,
+                    move_talk=move_talk,
+                    no_redirect=no_redirect,
+                )
+                stats["renamed"] += 1
+                logger.info("  MOVED: %s -> %s", title, new_title)
+            except mwclient.errors.APIError as exc:
+                stats["failed"] += 1
+                logger.error(
+                    "  FAILED (%s): %s -> %s : %s",
+                    getattr(exc, "code", "?"),
+                    title,
+                    new_title,
+                    getattr(exc, "info", exc),
+                )
+            except Exception as exc:  # pragma: no cover - safety net
+                stats["failed"] += 1
+                logger.exception("  FAILED: %s -> %s : %s", title, new_title, exc)
+
+        logger.info("  scanned %d page(s) under %s", ns_count, full_prefix)
+
+    return stats
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually perform the renames. Without this flag the script only lists candidates (dry-run).",
+    )
+    parser.add_argument(
+        "--host",
+        default="commons.wikimedia.org",
+        help="MediaWiki host (default: commons.wikimedia.org)",
+    )
+    parser.add_argument(
+        "--user-agent",
+        default="OWID-Rename-Bot/1.0 (https://github.com/Mdwiki-TD/svg_translate_web)",
+        help="User-Agent header (set per Wikimedia user-agent policy).",
+    )
+    parser.add_argument(
+        "--reason",
+        default="Capitalize first letter of OWID subpage name",
+        help="Move reason / log summary on the wiki.",
+    )
+    parser.add_argument(
+        "--no-redirect",
+        action="store_true",
+        help="Do not leave a redirect at the old title (needs the suppressredirect right).",
+    )
+    parser.add_argument(
+        "--no-move-talk",
+        action="store_true",
+        help="Do not move the associated talk page.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose (debug) logging.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    setup_logging(args.verbose)
+
+    username, password = load_credentials()
+    site = build_site(args.host, args.user_agent, username, password)
+
+    if args.apply:
+        logger.info("=== APPLY MODE: pages will be renamed on %s ===", args.host)
+    else:
+        logger.info("=== DRY-RUN MODE: no changes will be made (use --apply to rename) ===")
+
+    stats = process(
+        site,
+        apply=args.apply,
+        reason=args.reason,
+        move_talk=not args.no_move_talk,
+        no_redirect=args.no_redirect,
+    )
+
+    print()
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+    print(f"  Pages checked      : {stats['checked']}")
+    print(f"  Need rename        : {stats['to_rename']}")
+    if args.apply:
+        print(f"  Renamed            : {stats['renamed']}")
+        print(f"  Skipped (exists)   : {stats['skipped_exists']}")
+        print(f"  Failed             : {stats['failed']}")
+    else:
+        print("  (dry-run; rerun with --apply to perform the renames)")
+    print("=" * 60)
+
+    return 0 if stats.get("failed", 0) == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main_app/api_services/mwclient_page.py
+++ b/src/main_app/api_services/mwclient_page.py
@@ -105,3 +105,85 @@ class MwClientPage:
                 return edit_result
 
         return {"success": False, "error": "ratelimited"}
+
+    # ------------------------------------------------------------------
+    # Move (rename) page
+    # ------------------------------------------------------------------
+
+    def _move_page(
+        self,
+        page: mwclient.page.Page,
+        new_title: str,
+        reason: str,
+        move_talk: bool,
+        no_redirect: bool,
+    ) -> dict[str, any]:
+        try:
+            page.move(
+                new_title,
+                reason=reason,
+                move_talk=move_talk,
+                no_redirect=no_redirect,
+            )
+            return {"success": True}
+
+        except mwclient.errors.AssertUserFailedError:
+            return {"success": False, "error": "assertuserfailed"}
+
+        except mwclient.errors.UserBlocked:
+            return {"success": False, "error": "userblocked"}
+
+        except mwclient.errors.APIError as exc:
+            if exc.code == "ratelimited":
+                return {"success": False, "error": "ratelimited"}
+            return {"success": False, "error": exc.code, "details": str(exc)}
+
+        except Exception as exc:
+            logger.exception(f"Failed to move page {self.title} -> {new_title}", exc_info=exc)
+            return {"success": False, "error": str(exc)}
+
+    def move_page(
+        self,
+        new_title: str,
+        reason: str = "",
+        move_talk: bool = True,
+        no_redirect: bool = False,
+    ) -> dict[str, any]:
+        """Move (rename) the page, with rate-limit retry handling."""
+        page = self.load_page()
+
+        if not page:
+            return {"success": False, "error": self.load_page_error}
+
+        if not page.exists:
+            return {"success": False, "error": "missing"}
+
+        move_result = self._move_page(page, new_title, reason, move_talk, no_redirect)
+
+        if move_result.get("error") != "ratelimited":
+            return move_result
+
+        # handle retry
+        return self._move_with_retry(page, new_title, reason, move_talk, no_redirect)
+
+    def _move_with_retry(
+        self,
+        page: mwclient.page.Page,
+        new_title: str,
+        reason: str,
+        move_talk: bool,
+        no_redirect: bool,
+    ) -> dict[str, any]:
+        for attempt, delay in enumerate(_RETRY_DELAYS, start=1):
+            logger.warning(
+                f"Rate limited on move attempt {attempt}/{len(_RETRY_DELAYS)} "
+                f"for page '{self.title}' -> '{new_title}'. Retrying in {delay}s..."
+            )
+            time.sleep(delay)
+
+            move_result = self._move_page(page, new_title, reason, move_talk, no_redirect)
+
+            if move_result.get("error") != "ratelimited":
+                return move_result
+
+        return {"success": False, "error": "ratelimited"}

--- a/src/main_app/api_services/mwclient_page.py
+++ b/src/main_app/api_services/mwclient_page.py
@@ -47,6 +47,20 @@ class MwClientPage:
         logger.info(f"Title {self.title} exists")
         return True
 
+    def is_redirect(self) -> bool:
+        """Check if the page is a redirect using page.redirects_to()."""
+        page = self.load_page()
+
+        if not page or not page.exists:
+            return False
+
+        try:
+            target = page.redirects_to()
+            return target is not None
+        except Exception as exc:
+            logger.warning(f"Could not check redirect status of '{self.title}': {exc}")
+            return False
+
     def _edit_page(self, page: mwclient.page.Page, text: str, summary: str) -> dict[str, any]:
 
         try:

--- a/src/main_app/api_services/pages_api.py
+++ b/src/main_app/api_services/pages_api.py
@@ -17,6 +17,10 @@ def is_page_exists(page_title: str, site: mwclient.Site) -> bool:
     return MwClientPage(page_title, site).check_exists()
 
 
+def is_redirect(page_title: str, site: mwclient.Site) -> bool:
+    return MwClientPage(page_title, site).is_redirect()
+
+
 def edit_page(site: mwclient.Site, title: str, text: str, summary: str) -> dict[str, any]:
     return MwClientPage(title, site).edit_page(text, summary)
 
@@ -181,6 +185,7 @@ __all__ = [
     "create_page",
     "is_page_exists",
     "is_pages_exists",
+    "is_redirect",
     "move_page",
     "update_file_text",
     "update_page_text",

--- a/src/main_app/api_services/pages_api.py
+++ b/src/main_app/api_services/pages_api.py
@@ -21,6 +21,69 @@ def edit_page(site: mwclient.Site, title: str, text: str, summary: str) -> dict[
     return MwClientPage(title, site).edit_page(text, summary)
 
 
+def move_page(
+    site: mwclient.Site | None,
+    title: str,
+    new_title: str,
+    reason: str = "",
+    move_talk: bool = True,
+    no_redirect: bool = False,
+) -> dict[str, any]:
+    """
+    Move (rename) a page on Wikimedia Commons.
+
+    Args:
+        site: Authenticated mwclient.Site object for Commons.
+        title: Current page title (e.g. "Template:OWID/foo").
+        new_title: Target page title (e.g. "Template:OWID/Foo").
+        reason: Move reason / log summary on the wiki.
+        move_talk: Also move the associated talk page.
+        no_redirect: Do not leave a redirect at the old title (requires
+            the ``suppressredirect`` user right).
+
+    Returns:
+        A dictionary with ``success`` (bool) and ``error``/``details`` on failure,
+        matching the shape returned by :func:`create_page` / :func:`edit_page`.
+    """
+    missing_fields = verify_required_fields(
+        {"title": title, "new_title": new_title, "site": site}
+    )
+    if missing_fields:
+        list_str = ", ".join(missing_fields)
+        logger.error(f"Missing required fields for move_page: {list_str}")
+        return {"success": False, "error": f"Missing required fields: {list_str}"}
+
+    try:
+        page = site.pages[title]
+    except mwclient.errors.InvalidPageTitle:
+        logger.exception(f"Title {title} is invalid")
+        return {"success": False, "error": "invalidpagetitle"}
+    except Exception as exc:
+        logger.exception(f"Failed to load page {title}", exc_info=exc)
+        return {"success": False, "error": str(exc)}
+
+    if not page.exists:
+        return {"success": False, "error": "missing"}
+
+    try:
+        page.move(
+            new_title,
+            reason=reason,
+            move_talk=move_talk,
+            no_redirect=no_redirect,
+        )
+        return {"success": True}
+    except mwclient.errors.AssertUserFailedError:
+        return {"success": False, "error": "assertuserfailed"}
+    except mwclient.errors.UserBlocked:
+        return {"success": False, "error": "userblocked"}
+    except mwclient.errors.APIError as exc:
+        return {"success": False, "error": exc.code, "details": str(exc)}
+    except Exception as exc:
+        logger.exception(f"Failed to move page {title} -> {new_title}", exc_info=exc)
+        return {"success": False, "error": str(exc)}
+
+
 def create_page(
     page_name: str,
     wikitext: str,
@@ -141,6 +204,7 @@ __all__ = [
     "create_page",
     "is_page_exists",
     "is_pages_exists",
+    "move_page",
     "update_file_text",
     "update_page_text",
 ]

--- a/src/main_app/api_services/pages_api.py
+++ b/src/main_app/api_services/pages_api.py
@@ -53,35 +53,12 @@ def move_page(
         logger.error(f"Missing required fields for move_page: {list_str}")
         return {"success": False, "error": f"Missing required fields: {list_str}"}
 
-    try:
-        page = site.pages[title]
-    except mwclient.errors.InvalidPageTitle:
-        logger.exception(f"Title {title} is invalid")
-        return {"success": False, "error": "invalidpagetitle"}
-    except Exception as exc:
-        logger.exception(f"Failed to load page {title}", exc_info=exc)
-        return {"success": False, "error": str(exc)}
-
-    if not page.exists:
-        return {"success": False, "error": "missing"}
-
-    try:
-        page.move(
-            new_title,
-            reason=reason,
-            move_talk=move_talk,
-            no_redirect=no_redirect,
-        )
-        return {"success": True}
-    except mwclient.errors.AssertUserFailedError:
-        return {"success": False, "error": "assertuserfailed"}
-    except mwclient.errors.UserBlocked:
-        return {"success": False, "error": "userblocked"}
-    except mwclient.errors.APIError as exc:
-        return {"success": False, "error": exc.code, "details": str(exc)}
-    except Exception as exc:
-        logger.exception(f"Failed to move page {title} -> {new_title}", exc_info=exc)
-        return {"success": False, "error": str(exc)}
+    return MwClientPage(title, site).move_page(
+        new_title,
+        reason=reason,
+        move_talk=move_talk,
+        no_redirect=no_redirect,
+    )
 
 
 def create_page(

--- a/src/main_app/app_routes/admin/sidebar.py
+++ b/src/main_app/app_routes/admin/sidebar.py
@@ -107,6 +107,13 @@ def create_side(active_route, path: str | None = None):
                 icon="bi-file-earmark-text",
             ),
             SidebarItem(
+                id="rename_owid_pages",
+                admin=1,
+                href=_safe_url_for("admin.jobs.jobs_list", "/admin/jobs/rename_owid_pages", job_type="rename_owid_pages"),
+                title="Rename OWID Pages",
+                icon="bi-fonts",
+            ),
+            SidebarItem(
                 id="add_svglanguages_template",
                 admin=1,
                 href=_safe_url_for("admin.jobs.jobs_list", "/admin/jobs/add_svglanguages_template", job_type="add_svglanguages_template"),

--- a/src/main_app/jobs_workers/rename_owid_pages/__init__.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from .worker import rename_owid_pages_for_templates
+
+__all__ = [
+    "rename_owid_pages_for_templates",
+]

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Iterable
 import mwclient
 
 from ...api_services.clients import get_user_site
-from ...api_services.pages_api import is_page_exists, is_redirect, move_page
+from ...api_services.pages_api import edit_page, is_page_exists, is_redirect, move_page
 from ...sqlalchemy_db.services import get_template_by_title, update_template_data
 from ..base_worker import BaseJobWorker
 
@@ -111,7 +111,7 @@ class RenameOwidPagesWorker(BaseJobWorker):
                 "to_rename": 0,
                 "renamed": 0,
                 "skipped_target_exists": 0,
-                "need_action": 0,
+                "redirected": 0,
                 "failed": 0,
             },
             "pages_processed": [],
@@ -222,14 +222,8 @@ class RenameOwidPagesWorker(BaseJobWorker):
                 return
             else:
                 # Neither page redirects to the other — both are real pages.
-                # This is a conflict that requires manual intervention.
-                info.status = "need_action"
-                info.msg = (
-                    f"Both '{old_title}' and '{new_title}' exist as real pages "
-                    f"(neither redirects to the other). Manual action required."
-                )
-                self.result["summary"]["need_action"] += 1
-                self.result["pages_processed"].append(info.to_dict())
+                # Redirect the old (lowercase) page to the new (capitalized) one.
+                self._redirect_old_to_new(info, old_title, new_title)
                 return
 
         res = move_page(
@@ -252,6 +246,27 @@ class RenameOwidPagesWorker(BaseJobWorker):
             details = res.get("details")
             info.status = "failed"
             info.msg = f"{err}: {details}" if details else str(err)
+            self.result["summary"]["failed"] += 1
+
+        self.result["pages_processed"].append(info.to_dict())
+
+    def _redirect_old_to_new(self, info: RenameInfo, old_title: str, new_title: str) -> None:
+        """Turn the old (lowercase) page into a redirect to the new (capitalized) page."""
+        redirect_text = f"#REDIRECT [[{new_title}]]"
+        summary = f"Redirecting to [[{new_title}]] (capitalize first letter of OWID subpage)"
+
+        res = edit_page(self.site, old_title, redirect_text, summary)
+
+        if res.get("success"):
+            info.status = "redirected"
+            info.msg = f"Redirected {old_title} -> {new_title}"
+            self.result["summary"]["redirected"] += 1
+            self._update_template_title(old_title, new_title)
+        else:
+            err = res.get("error", "Unknown error")
+            details = res.get("details")
+            info.status = "failed"
+            info.msg = f"Failed to redirect: {err}: {details}" if details else f"Failed to redirect: {err}"
             self.result["summary"]["failed"] += 1
 
         self.result["pages_processed"].append(info.to_dict())

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Iterable
 import mwclient
 
 from ...api_services.clients import get_user_site
-from ...api_services.pages_api import is_page_exists, move_page
+from ...api_services.pages_api import is_page_exists, is_redirect, move_page
 from ...sqlalchemy_db.services import get_template_by_title, update_template_data
 from ..base_worker import BaseJobWorker
 
@@ -205,7 +205,7 @@ class RenameOwidPagesWorker(BaseJobWorker):
             # the move API will overwrite it — so we can proceed. But if it's a
             # real (non-redirect) page, we skip the move and just update the DB
             # title since the page already has the correct name on the wiki.
-            if not self._is_redirect(new_title):
+            if not is_redirect(new_title, self.site):
                 info.status = "skipped_target_exists"
                 info.msg = f"Target page already exists (not a redirect): {new_title}"
                 self.result["summary"]["skipped_target_exists"] += 1
@@ -238,18 +238,6 @@ class RenameOwidPagesWorker(BaseJobWorker):
             self.result["summary"]["failed"] += 1
 
         self.result["pages_processed"].append(info.to_dict())
-
-    def _is_redirect(self, title: str) -> bool:
-        """Check if *title* is a redirect page on the wiki."""
-        try:
-            page = self.site.pages[title]
-            target = page.redirects_to()
-            return target is not None
-        except Exception as exc:
-            logger.warning(
-                f"Job {self.job_id}: Could not check redirect status of '{title}': {exc}"
-            )
-            return False
 
     def _update_template_title(self, old_title: str, new_title: str) -> None:
         """Update TemplateRecord.title in the database after a successful move."""

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -243,7 +243,8 @@ class RenameOwidPagesWorker(BaseJobWorker):
         """Check if *title* is a redirect page on the wiki."""
         try:
             page = self.site.pages[title]
-            return page.redirect
+            target = page.redirects_to()
+            return target is not None
         except Exception as exc:
             logger.warning(
                 f"Job {self.job_id}: Could not check redirect status of '{title}': {exc}"

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -111,6 +111,7 @@ class RenameOwidPagesWorker(BaseJobWorker):
                 "to_rename": 0,
                 "renamed": 0,
                 "skipped_target_exists": 0,
+                "need_action": 0,
                 "failed": 0,
             },
             "pages_processed": [],
@@ -201,17 +202,33 @@ class RenameOwidPagesWorker(BaseJobWorker):
             )
 
         if target_exists:
-            # If the target is a redirect (e.g. left behind by a previous move),
-            # the move API will overwrite it — so we can proceed. But if it's a
-            # real (non-redirect) page, we skip the move and just update the DB
-            # title since the page already has the correct name on the wiki.
-            if not is_redirect(new_title, self.site):
+            # Both old_title and new_title exist on the wiki.
+            # Check redirect relationships to decide what to do:
+            target_is_redirect = is_redirect(new_title, self.site)
+            source_is_redirect = is_redirect(old_title, self.site)
+
+            if target_is_redirect:
+                # Target is a redirect (e.g. left behind by a previous move),
+                # the move API will overwrite it — proceed with the move below.
+                pass
+            elif source_is_redirect:
+                # The old page is already a redirect to the new one — just
+                # update the DB title to match the capitalized version.
                 info.status = "skipped_target_exists"
-                info.msg = f"Target page already exists (not a redirect): {new_title}"
+                info.msg = f"Old page redirects to target, updating DB only: {new_title}"
                 self.result["summary"]["skipped_target_exists"] += 1
-                # The target already exists with the correct capitalized name,
-                # so update the DB to reflect that.
                 self._update_template_title(old_title, new_title)
+                self.result["pages_processed"].append(info.to_dict())
+                return
+            else:
+                # Neither page redirects to the other — both are real pages.
+                # This is a conflict that requires manual intervention.
+                info.status = "need_action"
+                info.msg = (
+                    f"Both '{old_title}' and '{new_title}' exist as real pages "
+                    f"(neither redirects to the other). Manual action required."
+                )
+                self.result["summary"]["need_action"] += 1
                 self.result["pages_processed"].append(info.to_dict())
                 return
 

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -26,6 +26,7 @@ import mwclient
 
 from ...api_services.clients import get_user_site
 from ...api_services.pages_api import is_page_exists, move_page
+from ...sqlalchemy_db.services import get_template_by_title, update_template_data
 from ..base_worker import BaseJobWorker
 
 logger = logging.getLogger(__name__)
@@ -219,6 +220,8 @@ class RenameOwidPagesWorker(BaseJobWorker):
             info.status = "renamed"
             info.msg = f"Moved {old_title} -> {new_title}"
             self.result["summary"]["renamed"] += 1
+            # Update the title in the database
+            self._update_template_title(old_title, new_title)
         else:
             err = res.get("error", "Unknown error")
             details = res.get("details")
@@ -227,6 +230,24 @@ class RenameOwidPagesWorker(BaseJobWorker):
             self.result["summary"]["failed"] += 1
 
         self.result["pages_processed"].append(info.to_dict())
+
+    def _update_template_title(self, old_title: str, new_title: str) -> None:
+        """Update TemplateRecord.title in the database after a successful move."""
+        try:
+            record = get_template_by_title(old_title)
+            if record:
+                update_template_data(record.id, {"title": new_title})
+                logger.info(
+                    f"Job {self.job_id}: Updated DB template title: {old_title} -> {new_title}"
+                )
+            else:
+                logger.debug(
+                    f"Job {self.job_id}: No TemplateRecord found for '{old_title}', skipping DB update"
+                )
+        except Exception as exc:
+            logger.warning(
+                f"Job {self.job_id}: Failed to update DB title for '{old_title}': {exc}"
+            )
 
 
 def rename_owid_pages_for_templates(

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -1,0 +1,251 @@
+"""
+Worker module for rename_owid_pages.
+
+Lists every page whose title starts with ``Template:OWID/`` or ``OWID/`` on
+Wikimedia Commons and renames each one whose first character after ``OWID/``
+is a lowercase letter, e.g.::
+
+    Template:OWID/daily_meat_consumption_per_person
+        -> Template:OWID/Daily_meat_consumption_per_person
+    OWID/daily_meat_consumption_per_person
+        -> OWID/Daily_meat_consumption_per_person
+
+Authentication uses the current user's OAuth-bound mwclient.Site (no env
+credentials).
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Iterable
+
+import mwclient
+
+from ...api_services.clients import get_user_site
+from ...api_services.pages_api import is_page_exists, move_page
+from ..base_worker import BaseJobWorker
+
+logger = logging.getLogger(__name__)
+
+# (namespace_id, prefix_after_namespace, full_prefix_label_for_display)
+PREFIXES: tuple[tuple[int, str, str], ...] = (
+    (10, "OWID/", "Template:OWID/"),  # Template namespace
+    (0, "OWID/", "OWID/"),  # Main namespace
+)
+
+MOVE_REASON = "Capitalize first letter of OWID subpage name"
+
+
+@dataclass
+class RenameInfo:
+    """Holds the outcome of attempting to rename a single page."""
+
+    namespace: int
+    old_title: str
+    new_title: str | None = None
+    status: str = "pending"  # renamed | skipped_target_exists | failed
+    msg: str = ""
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "namespace": self.namespace,
+            "old_title": self.old_title,
+            "new_title": self.new_title,
+            "status": self.status,
+            "msg": self.msg,
+            "timestamp": self.timestamp,
+        }
+
+
+def needs_rename(title: str, full_prefix: str) -> tuple[bool, str]:
+    """Decide whether *title* needs a rename.
+
+    Only the first character after ``full_prefix`` is changed; everything
+    else (including spaces / underscores) is preserved as-is.
+
+    Returns ``(needs_rename, new_title)``.
+    """
+    if not title.startswith(full_prefix):
+        return False, title
+    rest = title[len(full_prefix):]
+    if not rest:
+        return False, title
+    first = rest[0]
+    if first.isalpha() and first.islower():
+        return True, full_prefix + first.upper() + rest[1:]
+    return False, title
+
+
+class RenameOwidPagesWorker(BaseJobWorker):
+    """Background worker that capitalizes OWID subpage names."""
+
+    def __init__(
+        self,
+        job_id: int,
+        user: dict[str, Any] | None,
+        cancel_event: threading.Event | None = None,
+    ) -> None:
+        self.site: mwclient.Site | None = None
+        super().__init__(job_id, user, cancel_event)
+
+    # ------------------------------------------------------------------
+    # BaseJobWorker hooks
+    # ------------------------------------------------------------------
+
+    def get_job_type(self) -> str:
+        return "rename_owid_pages"
+
+    def get_initial_result(self) -> Dict[str, Any]:
+        return {
+            "status": "pending",
+            "started_at": datetime.now().isoformat(),
+            "completed_at": None,
+            "cancelled_at": None,
+            "summary": {
+                "checked": 0,
+                "to_rename": 0,
+                "renamed": 0,
+                "skipped_target_exists": 0,
+                "failed": 0,
+            },
+            "pages_processed": [],
+        }
+
+    def process(self) -> Dict[str, Any]:
+        self.site = get_user_site(self.user)
+        if not self.site:
+            logger.warning(f"Job {self.job_id}: No site authentication available")
+            self.result["status"] = "failed"
+            self.result["error"] = "No authenticated user site available. Please log in via OAuth."
+            self.result["failed_at"] = datetime.now().isoformat()
+            return self.result
+
+        # First pass: collect candidates so progress is bounded and we can
+        # compute a sane save-progress interval.
+        candidates: list[tuple[int, str, str, str]] = []
+        for namespace, prefix, full_prefix in PREFIXES:
+            if self.is_cancelled():
+                return self.result
+
+            logger.info(
+                f"Job {self.job_id}: Listing pages with prefix '{full_prefix}' (ns={namespace})"
+            )
+            ns_count = 0
+            for page in self._iter_owid_pages(namespace, prefix):
+                ns_count += 1
+                self.result["summary"]["checked"] += 1
+                title = page.name
+                yes, new_title = needs_rename(title, full_prefix)
+                if not yes:
+                    continue
+                candidates.append((namespace, full_prefix, title, new_title))
+                self.result["summary"]["to_rename"] += 1
+
+            logger.info(f"Job {self.job_id}: Scanned {ns_count} page(s) under '{full_prefix}'")
+
+        total = len(candidates)
+        logger.info(f"Job {self.job_id}: {total} page(s) need renaming")
+
+        # Save progress immediately so the UI reflects the discovery phase.
+        self._save_progress()
+
+        per_item = self.get_priority(total) if total else 1
+
+        # Second pass: actually move.
+        for n, (namespace, _full_prefix, old_title, new_title) in enumerate(candidates, start=1):
+            if self.is_cancelled():
+                break
+
+            logger.info(f"Job {self.job_id}: Renaming {n}/{total}: {old_title} -> {new_title}")
+            self._rename_one(namespace, old_title, new_title)
+
+            if n == 1 or n % per_item == 0:
+                self._save_progress()
+
+        if self.result.get("status") in ("pending", "running"):
+            self.result["status"] = "completed"
+
+        return self.result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _iter_owid_pages(self, namespace: int, prefix: str) -> Iterable:
+        """Yield non-redirect pages with *prefix* in *namespace*.
+
+        ``filterredir='nonredirects'`` means redirects left behind by previous
+        runs of this job are not re-processed, keeping the job idempotent.
+        """
+        return self.site.allpages(
+            prefix=prefix,
+            namespace=namespace,
+            filterredir="nonredirects",
+        )
+
+    def _rename_one(self, namespace: int, old_title: str, new_title: str) -> None:
+        info = RenameInfo(namespace=namespace, old_title=old_title, new_title=new_title)
+
+        # Pre-flight: don't even try to move if the target already exists.
+        try:
+            target_exists = is_page_exists(new_title, self.site)
+        except Exception as exc:
+            target_exists = False
+            logger.exception(
+                f"Job {self.job_id}: Failed to check existence of {new_title}", exc_info=exc
+            )
+
+        if target_exists:
+            info.status = "skipped_target_exists"
+            info.msg = f"Target page already exists: {new_title}"
+            self.result["summary"]["skipped_target_exists"] += 1
+            self.result["pages_processed"].append(info.to_dict())
+            return
+
+        res = move_page(
+            self.site,
+            old_title,
+            new_title,
+            reason=MOVE_REASON,
+            move_talk=True,
+            no_redirect=False,
+        )
+
+        if res.get("success"):
+            info.status = "renamed"
+            info.msg = f"Moved {old_title} -> {new_title}"
+            self.result["summary"]["renamed"] += 1
+        else:
+            err = res.get("error", "Unknown error")
+            details = res.get("details")
+            info.status = "failed"
+            info.msg = f"{err}: {details}" if details else str(err)
+            self.result["summary"]["failed"] += 1
+
+        self.result["pages_processed"].append(info.to_dict())
+
+
+def rename_owid_pages_for_templates(
+    job_id: int,
+    user: Dict[str, Any] | None = None,
+    cancel_event: threading.Event | None = None,
+) -> None:
+    """Background worker entry-point."""
+    logger.info(f"Starting job {job_id}: rename OWID pages (capitalize first letter)")
+    worker = RenameOwidPagesWorker(
+        job_id=job_id,
+        user=user,
+        cancel_event=cancel_event,
+    )
+    worker.run()
+
+
+__all__ = [
+    "RenameOwidPagesWorker",
+    "needs_rename",
+    "rename_owid_pages_for_templates",
+]

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -201,11 +201,19 @@ class RenameOwidPagesWorker(BaseJobWorker):
             )
 
         if target_exists:
-            info.status = "skipped_target_exists"
-            info.msg = f"Target page already exists: {new_title}"
-            self.result["summary"]["skipped_target_exists"] += 1
-            self.result["pages_processed"].append(info.to_dict())
-            return
+            # If the target is a redirect (e.g. left behind by a previous move),
+            # the move API will overwrite it — so we can proceed. But if it's a
+            # real (non-redirect) page, we skip the move and just update the DB
+            # title since the page already has the correct name on the wiki.
+            if not self._is_redirect(new_title):
+                info.status = "skipped_target_exists"
+                info.msg = f"Target page already exists (not a redirect): {new_title}"
+                self.result["summary"]["skipped_target_exists"] += 1
+                # The target already exists with the correct capitalized name,
+                # so update the DB to reflect that.
+                self._update_template_title(old_title, new_title)
+                self.result["pages_processed"].append(info.to_dict())
+                return
 
         res = move_page(
             self.site,
@@ -230,6 +238,17 @@ class RenameOwidPagesWorker(BaseJobWorker):
             self.result["summary"]["failed"] += 1
 
         self.result["pages_processed"].append(info.to_dict())
+
+    def _is_redirect(self, title: str) -> bool:
+        """Check if *title* is a redirect page on the wiki."""
+        try:
+            page = self.site.pages[title]
+            return page.redirect
+        except Exception as exc:
+            logger.warning(
+                f"Job {self.job_id}: Could not check redirect status of '{title}': {exc}"
+            )
+            return False
 
     def _update_template_title(self, old_title: str, new_title: str) -> None:
         """Update TemplateRecord.title in the database after a successful move."""

--- a/src/main_app/jobs_workers/workers_list.py
+++ b/src/main_app/jobs_workers/workers_list.py
@@ -6,6 +6,7 @@ from .create_owid_pages import create_owid_pages_for_templates
 from .crop_main_files import crop_main_files_for_templates
 from .download_main_files_worker import download_main_files_for_templates
 from .fix_nested_main_files_worker import fix_nested_main_files_for_templates
+from .rename_owid_pages import rename_owid_pages_for_templates
 
 jobs_targets_public = {
     "copy_svg_langs": copy_svg_langs_worker_entry,
@@ -17,6 +18,7 @@ jobs_targets = {
     "collect_main_files": collect_main_files_for_templates,
     "crop_main_files": crop_main_files_for_templates,
     "create_owid_pages": create_owid_pages_for_templates,
+    "rename_owid_pages": rename_owid_pages_for_templates,
     "add_svglanguages_template": add_svglanguages_template_to_templates,
     "download_main_files": download_main_files_for_templates,
 }
@@ -26,6 +28,7 @@ JOB_TYPE_TEMPLATES = {
     "collect_main_files": "admins/jobs_templates/collect_main_files/details.html",
     "crop_main_files": "admins/jobs_templates/crop_main_files/details.html",
     "create_owid_pages": "admins/jobs_templates/create_owid_pages/details.html",
+    "rename_owid_pages": "admins/jobs_templates/rename_owid_pages/details.html",
     "fix_nested_main_files": "admins/jobs_templates/fix_nested_main_files/details.html",
     "download_main_files": "admins/jobs_templates/download_main_files/details.html",
     "add_svglanguages_template": "admins/jobs_templates/add_svglanguages_template/details.html",
@@ -36,6 +39,7 @@ JOB_TYPE_LIST_TEMPLATES = {
     "collect_main_files": "admins/jobs_templates/collect_main_files/list.html",
     "crop_main_files": "admins/jobs_templates/crop_main_files/list.html",
     "create_owid_pages": "admins/jobs_templates/create_owid_pages/list.html",
+    "rename_owid_pages": "admins/jobs_templates/rename_owid_pages/list.html",
     "fix_nested_main_files": "admins/jobs_templates/fix_nested_main_files/list.html",
     "download_main_files": "admins/jobs_templates/download_main_files/list.html",
     "add_svglanguages_template": "admins/jobs_templates/add_svglanguages_template/list.html",

--- a/src/templates/admins/jobs_templates/rename_owid_pages/details.html
+++ b/src/templates/admins/jobs_templates/rename_owid_pages/details.html
@@ -8,7 +8,7 @@
 
 {% block job_summary %}
 {% if result_data.summary %}
-<div class="row row-cols-2 row-cols-md-5 g-2 text-center mb-3">
+<div class="row row-cols-2 row-cols-md-6 g-2 text-center mb-3">
     <div class="col">
         <div class="card h-100 border">
             <div class="card-body p-2">
@@ -42,6 +42,14 @@
         </div>
     </div>
     <div class="col">
+        <div class="card h-100 border-warning">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.need_action or 0 }}</h4>
+                <small>Need Action</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
         <div class="card h-100 border-danger">
             <div class="card-body p-2">
                 <h4 class="mb-0">{{ result_data.summary.failed or 0 }}</h4>
@@ -58,6 +66,7 @@
 
 {% set renamed_pages = result_data.pages_processed | selectattr("status", "equalto", "renamed") | list %}
 {% set skipped_pages = result_data.pages_processed | selectattr("status", "equalto", "skipped_target_exists") | list %}
+{% set need_action_pages = result_data.pages_processed | selectattr("status", "equalto", "need_action") | list %}
 {% set failed_pages = result_data.pages_processed | selectattr("status", "equalto", "failed") | list %}
 
 <!-- Renamed -->
@@ -124,6 +133,56 @@
                 </thead>
                 <tbody>
                     {% for item in skipped_pages %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.old_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.old_title }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if item.new_title %}
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.new_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.new_title }}
+                            </a>
+                            {% else %} - {% endif %}
+                        </td>
+                        <td><small class="text-muted">{{ item.msg }}</small></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Need Action -->
+{% if need_action_pages %}
+<div class="card mb-3">
+    <div class="card-header bg-warning bg-opacity-10">
+        {{ card_header("Need Action (" ~ need_action_pages|length ~ ")") }}
+    </div>
+    <div class="card-body">
+        <div class="alert alert-warning mb-3">
+            <i class="bi bi-exclamation-triangle"></i>
+            Both the old and new page titles exist as real pages (neither redirects to the other).
+            These require manual intervention to resolve.
+        </div>
+        <div class="table-responsive">
+            <table class="table table-striped table-sm DataTable">
+                <thead>
+                    <tr>
+                        <th style="width: 4%">#</th>
+                        <th>Old title</th>
+                        <th>New title</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in need_action_pages %}
                     <tr>
                         <td>{{ loop.index }}</td>
                         <td>

--- a/src/templates/admins/jobs_templates/rename_owid_pages/details.html
+++ b/src/templates/admins/jobs_templates/rename_owid_pages/details.html
@@ -55,9 +55,16 @@
 
 {% block job_details %}
 {% if result_data.pages_processed %}
+
+{% set renamed_pages = result_data.pages_processed | selectattr("status", "equalto", "renamed") | list %}
+{% set skipped_pages = result_data.pages_processed | selectattr("status", "equalto", "skipped_target_exists") | list %}
+{% set failed_pages = result_data.pages_processed | selectattr("status", "equalto", "failed") | list %}
+
+<!-- Renamed -->
+{% if renamed_pages %}
 <div class="card mb-3">
-    <div class="card-header">
-        {{ card_header("Pages Processed (" ~ result_data.pages_processed|length ~ ")") }}
+    <div class="card-header bg-success bg-opacity-10">
+        {{ card_header("Renamed (" ~ renamed_pages|length ~ ")") }}
     </div>
     <div class="card-body">
         <div class="table-responsive">
@@ -67,12 +74,11 @@
                         <th style="width: 4%">#</th>
                         <th>Old title</th>
                         <th>New title</th>
-                        <th style="width: 15%">Status</th>
                         <th>Message</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for item in result_data.pages_processed %}
+                    {% for item in renamed_pages %}
                     <tr>
                         <td>{{ loop.index }}</td>
                         <td>
@@ -89,16 +95,50 @@
                             </a>
                             {% else %} - {% endif %}
                         </td>
+                        <td><small class="text-muted">{{ item.msg }}</small></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<!-- Skipped (target exists) -->
+{% if skipped_pages %}
+<div class="card mb-3">
+    <div class="card-header bg-secondary bg-opacity-10">
+        {{ card_header("Skipped (target exists) (" ~ skipped_pages|length ~ ")") }}
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm DataTable">
+                <thead>
+                    <tr>
+                        <th style="width: 4%">#</th>
+                        <th>Old title</th>
+                        <th>New title</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in skipped_pages %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
                         <td>
-                            {% if item.status == 'renamed' %}
-                            <span class="badge bg-success">renamed</span>
-                            {% elif item.status == 'skipped_target_exists' %}
-                            <span class="badge bg-secondary">skipped</span>
-                            {% elif item.status == 'failed' %}
-                            <span class="badge bg-danger">failed</span>
-                            {% else %}
-                            <span class="badge bg-light text-dark">{{ item.status }}</span>
-                            {% endif %}
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.old_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.old_title }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if item.new_title %}
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.new_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.new_title }}
+                            </a>
+                            {% else %} - {% endif %}
                         </td>
                         <td><small class="text-muted">{{ item.msg }}</small></td>
                     </tr>
@@ -108,5 +148,52 @@
         </div>
     </div>
 </div>
+{% endif %}
+
+<!-- Failed -->
+{% if failed_pages %}
+<div class="card mb-3">
+    <div class="card-header bg-danger bg-opacity-10">
+        {{ card_header("Failed (" ~ failed_pages|length ~ ")") }}
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm DataTable">
+                <thead>
+                    <tr>
+                        <th style="width: 4%">#</th>
+                        <th>Old title</th>
+                        <th>New title</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in failed_pages %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.old_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.old_title }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if item.new_title %}
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.new_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.new_title }}
+                            </a>
+                            {% else %} - {% endif %}
+                        </td>
+                        <td><small class="text-muted">{{ item.msg }}</small></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 {% endif %}
 {% endblock %}

--- a/src/templates/admins/jobs_templates/rename_owid_pages/details.html
+++ b/src/templates/admins/jobs_templates/rename_owid_pages/details.html
@@ -1,0 +1,112 @@
+{% extends "admins/jobs_templates/base_details.html" %}
+{% from "_macros.html" import card_header %}
+
+{% set job_type = 'rename_owid_pages' %}
+
+{% block detail_title %}Rename OWID Pages{% endblock %}
+{% block detail_headline %}Rename OWID Pages{% endblock %}
+
+{% block job_summary %}
+{% if result_data.summary %}
+<div class="row row-cols-2 row-cols-md-5 g-2 text-center mb-3">
+    <div class="col">
+        <div class="card h-100 border">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.checked or 0 }}</h4>
+                <small class="text-muted">Checked</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-primary">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.to_rename or 0 }}</h4>
+                <small>Need rename</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-success">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.renamed or 0 }}</h4>
+                <small>Renamed</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-secondary">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.skipped_target_exists or 0 }}</h4>
+                <small>Skipped (target exists)</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-danger">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.failed or 0 }}</h4>
+                <small>Failed</small>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block job_details %}
+{% if result_data.pages_processed %}
+<div class="card mb-3">
+    <div class="card-header">
+        {{ card_header("Pages Processed (" ~ result_data.pages_processed|length ~ ")") }}
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm DataTable">
+                <thead>
+                    <tr>
+                        <th style="width: 4%">#</th>
+                        <th>Old title</th>
+                        <th>New title</th>
+                        <th style="width: 15%">Status</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in result_data.pages_processed %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.old_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.old_title }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if item.new_title %}
+                            <a href="https://commons.wikimedia.org/wiki/{{ item.new_title }}" target="_blank"
+                                rel="noopener noreferrer">
+                                {{ item.new_title }}
+                            </a>
+                            {% else %} - {% endif %}
+                        </td>
+                        <td>
+                            {% if item.status == 'renamed' %}
+                            <span class="badge bg-success">renamed</span>
+                            {% elif item.status == 'skipped_target_exists' %}
+                            <span class="badge bg-secondary">skipped</span>
+                            {% elif item.status == 'failed' %}
+                            <span class="badge bg-danger">failed</span>
+                            {% else %}
+                            <span class="badge bg-light text-dark">{{ item.status }}</span>
+                            {% endif %}
+                        </td>
+                        <td><small class="text-muted">{{ item.msg }}</small></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/src/templates/admins/jobs_templates/rename_owid_pages/details.html
+++ b/src/templates/admins/jobs_templates/rename_owid_pages/details.html
@@ -42,10 +42,10 @@
         </div>
     </div>
     <div class="col">
-        <div class="card h-100 border-warning">
+        <div class="card h-100 border-info">
             <div class="card-body p-2">
-                <h4 class="mb-0">{{ result_data.summary.need_action or 0 }}</h4>
-                <small>Need Action</small>
+                <h4 class="mb-0">{{ result_data.summary.redirected or 0 }}</h4>
+                <small>Redirected</small>
             </div>
         </div>
     </div>
@@ -66,7 +66,7 @@
 
 {% set renamed_pages = result_data.pages_processed | selectattr("status", "equalto", "renamed") | list %}
 {% set skipped_pages = result_data.pages_processed | selectattr("status", "equalto", "skipped_target_exists") | list %}
-{% set need_action_pages = result_data.pages_processed | selectattr("status", "equalto", "need_action") | list %}
+{% set redirected_pages = result_data.pages_processed | selectattr("status", "equalto", "redirected") | list %}
 {% set failed_pages = result_data.pages_processed | selectattr("status", "equalto", "failed") | list %}
 
 <!-- Renamed -->
@@ -159,30 +159,30 @@
 </div>
 {% endif %}
 
-<!-- Need Action -->
-{% if need_action_pages %}
+<!-- Redirected -->
+{% if redirected_pages %}
 <div class="card mb-3">
-    <div class="card-header bg-warning bg-opacity-10">
-        {{ card_header("Need Action (" ~ need_action_pages|length ~ ")") }}
+    <div class="card-header bg-info bg-opacity-10">
+        {{ card_header("Redirected (" ~ redirected_pages|length ~ ")") }}
     </div>
     <div class="card-body">
-        <div class="alert alert-warning mb-3">
-            <i class="bi bi-exclamation-triangle"></i>
-            Both the old and new page titles exist as real pages (neither redirects to the other).
-            These require manual intervention to resolve.
+        <div class="alert alert-info mb-3">
+            <i class="bi bi-arrow-right-circle"></i>
+            Both the old and new page titles existed as real pages. The old (lowercase) page
+            was turned into a redirect pointing to the new (capitalized) page.
         </div>
         <div class="table-responsive">
             <table class="table table-striped table-sm DataTable">
                 <thead>
                     <tr>
                         <th style="width: 4%">#</th>
-                        <th>Old title</th>
-                        <th>New title</th>
+                        <th>Old title (now redirect)</th>
+                        <th>New title (target)</th>
                         <th>Message</th>
                     </tr>
                 </thead>
                 <tbody>
-                    {% for item in need_action_pages %}
+                    {% for item in redirected_pages %}
                     <tr>
                         <td>{{ loop.index }}</td>
                         <td>

--- a/src/templates/admins/jobs_templates/rename_owid_pages/list.html
+++ b/src/templates/admins/jobs_templates/rename_owid_pages/list.html
@@ -1,0 +1,24 @@
+{% extends "admins/jobs_templates/base_list.html" %}
+
+{% set job_type = 'rename_owid_pages' %}
+
+{% block list_title %}Rename OWID Pages{% endblock %}
+{% block list_headline %}Rename OWID Pages{% endblock %}
+
+{% block start_confirm_message %}This will start a background job that renames every Template:OWID/* and OWID/* page whose first character after "OWID/" is lowercase. Continue?{% endblock %}
+{% block start_icon %}bi-fonts{% endblock %}
+
+{% block list_info %}
+<div class="alert alert-info mb-3">
+    <i class="bi bi-info-circle"></i>
+    This job lists all pages under <code>Template:OWID/</code> and <code>OWID/</code> on
+    Wikimedia Commons and renames any whose first character after <code>OWID/</code> is a
+    lowercase letter, capitalizing it. Example:
+    <br>
+    <code>Template:OWID/daily_meat_consumption_per_person</code>
+    &rarr; <code>Template:OWID/Daily_meat_consumption_per_person</code>
+    <br>
+    Renames are performed using your own OAuth account; a redirect is left
+    behind at the old title.
+</div>
+{% endblock %}


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @MrIbrahem :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds `_works_files/rename_owid_pages.py`, a standalone CLI (not wired into the Flask app) that walks every page under `Template:OWID/` and `OWID/` on Wikimedia Commons and renames each one whose first character after `OWID/` is lowercase.

Examples:

- `Template:OWID/daily_meat_consumption_per_person` → `Template:OWID/Daily_meat_consumption_per_person`
- `OWID/daily_meat_consumption_per_person` → `OWID/Daily_meat_consumption_per_person`

## Behavior

- Uses `mwclient` (already in `requirements.txt`) for `allpages` listing and `Page.move`.
- Reads `WIKI_USERNAME` / `WIKI_PASSWORD` from `.env` via `python-dotenv`. Recommended to use [Special:BotPasswords](https://commons.wikimedia.org/wiki/Special:BotPasswords) (`User@Botname` form).
- **Dry-run by default**; pass `--apply` to actually perform the moves.
- Filters out redirects during listing (`filterredir=nonredirects`) so re-running the script after a successful pass is idempotent.
- Skips pages whose target title already exists.
- Only renames when the first char after `OWID/` is a lowercase letter; non-alpha (e.g. digits) and already-capitalized titles are left alone.
- Flags: `--no-redirect` (suppress redirects, needs the right), `--no-move-talk`, `--host`, `--user-agent`, `--reason`, `-v/--verbose`.

## Usage

```bash
# List candidates only:
python _works_files/rename_owid_pages.py

# Actually rename:
python _works_files/rename_owid_pages.py --apply
```

## Tested

- `python -m py_compile` clean.
- `needs_rename()` verified against 9 cases: lowercase, already-capitalized, digit-prefixed, empty rest, spaces, accented chars, wrong-prefix.
- CLI argparse defaults verified.
- Live run against Commons not exercised in CI; relies on the user's bot credentials.

## Known limitations

- Move rights / rate limits are enforced by MediaWiki — failures are logged with the API error code and counted in the summary, the script keeps going.
- Does not update inbound transclusions/links; MediaWiki's automatic redirect (left in place by default) keeps existing usages working. Pass `--no-redirect` only if you've already migrated transclusions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin “Rename OWID Pages” background job with UI to start, monitor, and view detailed results (counts and per-page outcomes).
  * Added list and details pages for the job in the admin interface.
  * Added a maintenance CLI tool to scan Wikimedia Commons for OWID-page naming issues and optionally perform renames (dry-run and apply modes, talk/redirect options).

* **Chores**
  * Added configuration placeholders and docs for Wikimedia Commons authentication credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mdwiki-TD/svg_translate_web/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->