### PR TITLE
feat: add Update All option to Collect Templates data job

### DIFF
--- a/src/main_app/jobs_workers/add_svglanguages_template/worker.py
+++ b/src/main_app/jobs_workers/add_svglanguages_template/worker.py
@@ -278,10 +278,18 @@ class AddSvgSVGLanguagesTemplate(BaseJobWorker):
 def add_svglanguages_template_to_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> None:
     """
     Background worker
+
+    Args:
+        job_id: The job ID
+        user: User authentication data
+        cancel_event: Threading event for cancellation
+        args: Optional arguments dict (unused, for unified signature)
     """
     logger.info(f"Starting job {job_id}: add {{{{SVGLanguages|...}}}} template to templates pages.")
     worker = AddSvgSVGLanguagesTemplate(

--- a/src/main_app/jobs_workers/collect_main_files_worker.py
+++ b/src/main_app/jobs_workers/collect_main_files_worker.py
@@ -302,35 +302,22 @@ class CollectMainFilesWorker(BaseJobWorker):
 def collect_main_files_for_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
-) -> None:
-    """
-    Background worker to collect templates data for templates that don't have one.
-
-    This function:
-    1. Fetches all templates from the database
-    2. For each template without a main_file:
-       - Fetches the wikitext from Commons
-       - Extracts the main file using find_main_title
-       - Updates the template in the database
-    3. Saves a detailed report to a JSON file
-    """
-    logger.info(f"Starting job {job_id}: collect templates data for templates")
-    worker = CollectMainFilesWorker(job_id, user, cancel_event)
-    worker.run()
-
-
-def collect_main_files_for_templates_with_args(
-    job_id: int,
     args: Dict[str, Any] | None = None,
-    user: Dict[str, Any] | None = None,
-    cancel_event: threading.Event | None = None,
 ) -> None:
     """
-    Background worker to collect/update templates data with arguments.
+    Background worker to collect templates data.
 
-    Supports args:
-        update_all: "true" to update all templates, not just those missing data.
+    By default only processes templates missing data. Pass args={"update_all": "true"}
+    to re-fetch and update ALL templates.
+
+    Args:
+        job_id: The job ID
+        user: User authentication data
+        cancel_event: Threading event for cancellation
+        args: Optional arguments dict. Supports:
+            - update_all: "true" to update all templates, not just those missing data.
     """
     update_all = False
     if args and args.get("update_all", "").lower() == "true":
@@ -343,6 +330,5 @@ def collect_main_files_for_templates_with_args(
 
 __all__ = [
     "collect_main_files_for_templates",
-    "collect_main_files_for_templates_with_args",
     "CollectMainFilesWorker",
 ]

--- a/src/main_app/jobs_workers/collect_main_files_worker.py
+++ b/src/main_app/jobs_workers/collect_main_files_worker.py
@@ -60,6 +60,16 @@ def slugify_title(title: str) -> str:
 class CollectMainFilesWorker(BaseJobWorker):
     """Worker for collecting main files for templates."""
 
+    def __init__(
+        self,
+        job_id: int,
+        user: Dict[str, Any] | None = None,
+        cancel_event: threading.Event | None = None,
+        update_all: bool = False,
+    ) -> None:
+        super().__init__(job_id, user, cancel_event)
+        self.update_all = update_all
+
     def get_job_type(self) -> str:
         """Return the job type identifier."""
         return "collect_main_files"
@@ -165,8 +175,14 @@ class CollectMainFilesWorker(BaseJobWorker):
             [t for t in templates if t.main_file and t.last_world_file and t.source]
         )
 
-        templates_to_process = [t for t in templates if not (t.main_file and t.last_world_file and t.source)]
-        logger.info(f"Job {self.job_id}: Found {len(templates)} templates, {len(templates_to_process)} need processing")
+        if self.update_all:
+            templates_to_process = templates
+            logger.info(f"Job {self.job_id}: Update all mode - processing all {len(templates_to_process)} templates")
+        else:
+            templates_to_process = [t for t in templates if not (t.main_file and t.last_world_file and t.source)]
+            logger.info(
+                f"Job {self.job_id}: Found {len(templates)} templates, {len(templates_to_process)} need processing"
+            )
 
         per_item = self.get_priority(len(templates_to_process))
 
@@ -304,7 +320,29 @@ def collect_main_files_for_templates(
     worker.run()
 
 
+def collect_main_files_for_templates_with_args(
+    job_id: int,
+    args: Dict[str, Any] | None = None,
+    user: Dict[str, Any] | None = None,
+    cancel_event: threading.Event | None = None,
+) -> None:
+    """
+    Background worker to collect/update templates data with arguments.
+
+    Supports args:
+        update_all: "true" to update all templates, not just those missing data.
+    """
+    update_all = False
+    if args and args.get("update_all", "").lower() == "true":
+        update_all = True
+
+    logger.info(f"Starting job {job_id}: collect templates data (update_all={update_all})")
+    worker = CollectMainFilesWorker(job_id, user, cancel_event, update_all=update_all)
+    worker.run()
+
+
 __all__ = [
     "collect_main_files_for_templates",
+    "collect_main_files_for_templates_with_args",
     "CollectMainFilesWorker",
 ]

--- a/src/main_app/jobs_workers/create_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/create_owid_pages/worker.py
@@ -327,10 +327,18 @@ class CreateOwidPagesWorker(BaseJobWorker):
 def create_owid_pages_for_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> None:
     """
     Background worker
+
+    Args:
+        job_id: The job ID
+        user: User authentication data
+        cancel_event: Threading event for cancellation
+        args: Optional arguments dict (unused, for unified signature)
     """
     logger.info(f"Starting job {job_id}: create OWID pages for templates")
     worker = CreateOwidPagesWorker(

--- a/src/main_app/jobs_workers/crop_main_files/worker.py
+++ b/src/main_app/jobs_workers/crop_main_files/worker.py
@@ -61,7 +61,9 @@ class CropMainFilesWorker(BaseJobWorker):
 def crop_main_files_for_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> None:
     """
     Entry point for crop newest world files background job.
@@ -70,6 +72,7 @@ def crop_main_files_for_templates(
         job_id: The job ID
         user: User authentication data for OAuth uploads
         cancel_event: Threading event for cancellation
+        args: Optional arguments dict (unused, for unified signature)
     """
     worker = CropMainFilesWorker(job_id, user, cancel_event)
     worker.run()

--- a/src/main_app/jobs_workers/download_main_files_worker.py
+++ b/src/main_app/jobs_workers/download_main_files_worker.py
@@ -237,22 +237,18 @@ class DownloadMainFilesWorker(BaseJobWorker):
 def download_main_files_for_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> None:
     """
     Background worker to download main files for all templates.
-
-    This function:
-    1. Fetches all templates from the database
-    2. For each template with a main_file:
-       - Downloads the file from Commons
-       - Saves it to settings.paths.main_files_path
-    3. Saves a detailed report to a JSON file
 
     Args:
         job_id: The job ID
         user: User authentication data (not used for downloads, but kept for consistency)
         cancel_event: Optional event to check for cancellation
+        args: Optional arguments dict (unused, for unified signature)
     """
     logger.info(f"Starting job {job_id}: download main files for templates")
     worker = DownloadMainFilesWorker(job_id, user, cancel_event)

--- a/src/main_app/jobs_workers/fix_nested_main_files_worker.py
+++ b/src/main_app/jobs_workers/fix_nested_main_files_worker.py
@@ -241,22 +241,18 @@ class FixNestedMainFilesWorker(BaseJobWorker):
 def fix_nested_main_files_for_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> None:
     """
     Background worker to run fix_nested task on all main files from templates.
-
-    This function:
-    1. Fetches all templates from the database
-    2. For each template with a main_file:
-       - Runs the fix_nested process (download, fix, upload)
-       - Uses the user's OAuth credentials for file uploads
-    3. Saves a detailed report to a JSON file
 
     Args:
         job_id: The job ID
         user: User authentication data for OAuth uploads
         cancel_event: Optional event to check for cancellation
+        args: Optional arguments dict (unused, for unified signature)
     """
     logger.info(f"Starting job {job_id}: fix nested tags for template main files")
     worker = FixNestedMainFilesWorker(job_id, user, cancel_event)

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -1,4 +1,4 @@
-"""Worker module for collecting main files for templates."""
+"""Worker module for managing background jobs."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ from ..sqlalchemy_db.services import cancel_job as cancel_job_db
 from ..sqlalchemy_db.services import (
     create_job,
 )
-from .workers_list import jobs_targets, jobs_targets_public, jobs_targets_with_args
+from .workers_list import jobs_targets, jobs_targets_public
 
 logger = logging.getLogger(__name__)
 
@@ -42,25 +42,11 @@ def _runner(
     cancel_event: threading.Event,
     target_func: Any,
     flask_app: Flask,
+    args: Dict[str, Any] | None = None,
 ) -> None:
     with flask_app.app_context():
         try:
-            target_func(task_id, user, cancel_event=cancel_event)
-        finally:
-            _pop_cancel_event(task_id)
-
-
-def _runner_with_args(
-    task_id: int,
-    args: Dict[str, Any] | None,
-    user: Dict[str, Any] | None,
-    cancel_event: threading.Event,
-    target_func: Any,
-    flask_app: Flask,
-) -> None:
-    with flask_app.app_context():
-        try:
-            target_func(task_id, args, user, cancel_event=cancel_event)
+            target_func(task_id, user, cancel_event=cancel_event, args=args)
         finally:
             _pop_cancel_event(task_id)
 
@@ -87,13 +73,15 @@ def cancel_job(task_id: int, job_type: str | None = None) -> bool:
     return local_cancelled or db_cancelled
 
 
-def start_job(user: Dict[str, Any] | None, job_type: str) -> int:
+def start_job(user: Dict[str, Any] | None, job_type: str, args: Dict[str, Any] | None = None) -> int:
     """
-    Start a background job to fix nested tags in all template main files.
+    Start a background job.
     Returns the job ID.
 
     Args:
         user: User authentication data for OAuth uploads
+        job_type: The type of job to start
+        args: Optional arguments to pass to the worker
     """
     job_func = jobs_targets.get(job_type) or jobs_targets_public.get(job_type)
     if not job_func:
@@ -113,7 +101,7 @@ def start_job(user: Dict[str, Any] | None, job_type: str) -> int:
     # Start background thread
     thread = threading.Thread(
         target=_runner,
-        args=(job.id, user, cancel_event, job_func, flask_app),
+        args=(job.id, user, cancel_event, job_func, flask_app, args),
         daemon=True,
     )
     thread.start()
@@ -123,40 +111,8 @@ def start_job(user: Dict[str, Any] | None, job_type: str) -> int:
     return job.id
 
 
-def start_job_with_args(user: Dict[str, Any] | None, job_type: str, args: Dict[str, Any]) -> int:
-    """
-    Start a background job with the provided arguments.
-    Returns the job ID.
-
-    Args:
-        user: User authentication data for OAuth uploads
-    """
-    job_func = jobs_targets_with_args.get(job_type) or jobs_targets_public.get(job_type)
-    if not job_func:
-        raise ValueError(f"Unknown job type: {job_type}")
-
-    username = user.get("username") if user else None
-
-    # Create job record
-    job = create_job(job_type, username)
-
-    cancel_event = threading.Event()
-    _register_cancel_event(job.id, cancel_event)
-
-    # Capture the Flask app for the background thread (requires app context)
-    flask_app = current_app._get_current_object()
-
-    # Start background thread
-    thread = threading.Thread(
-        target=_runner_with_args,
-        args=(job.id, args, user, cancel_event, job_func, flask_app),
-        daemon=True,
-    )
-    thread.start()
-
-    logger.info(f"Started background job {job.id} for {job_type}")
-
-    return job.id
+# Keep backward-compatible alias
+start_job_with_args = start_job
 
 
 __all__ = [

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -131,7 +131,7 @@ def start_job_with_args(user: Dict[str, Any] | None, job_type: str, args: Dict[s
     Args:
         user: User authentication data for OAuth uploads
     """
-    job_func = jobs_targets_with_args.get(job_type) or jobs_targets_public.get(job_type)
+    job_func = jobs_targets_with_args.get(job_type) or jobs_targets_public.get(job_type) or jobs_targets.get(job_type)
     if not job_func:
         raise ValueError(f"Unknown job type: {job_type}")
 

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -12,7 +12,7 @@ from ..sqlalchemy_db.services import cancel_job as cancel_job_db
 from ..sqlalchemy_db.services import (
     create_job,
 )
-from .workers_list import jobs_targets, jobs_targets_public
+from .workers_list import jobs_targets, jobs_targets_public, jobs_targets_with_args
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +131,7 @@ def start_job_with_args(user: Dict[str, Any] | None, job_type: str, args: Dict[s
     Args:
         user: User authentication data for OAuth uploads
     """
-    job_func = jobs_targets.get(job_type) or jobs_targets_public.get(job_type)
+    job_func = jobs_targets_with_args.get(job_type) or jobs_targets_public.get(job_type)
     if not job_func:
         raise ValueError(f"Unknown job type: {job_type}")
 

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -131,7 +131,7 @@ def start_job_with_args(user: Dict[str, Any] | None, job_type: str, args: Dict[s
     Args:
         user: User authentication data for OAuth uploads
     """
-    job_func = jobs_targets_with_args.get(job_type) or jobs_targets_public.get(job_type) or jobs_targets.get(job_type)
+    job_func = jobs_targets_with_args.get(job_type) or jobs_targets_public.get(job_type)
     if not job_func:
         raise ValueError(f"Unknown job type: {job_type}")
 

--- a/src/main_app/jobs_workers/rename_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/rename_owid_pages/worker.py
@@ -293,9 +293,18 @@ class RenameOwidPagesWorker(BaseJobWorker):
 def rename_owid_pages_for_templates(
     job_id: int,
     user: Dict[str, Any] | None = None,
+    *,
     cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
 ) -> None:
-    """Background worker entry-point."""
+    """Background worker entry-point.
+
+    Args:
+        job_id: The job ID
+        user: User authentication data
+        cancel_event: Threading event for cancellation
+        args: Optional arguments dict (unused, for unified signature)
+    """
     logger.info(f"Starting job {job_id}: rename OWID pages (capitalize first letter)")
     worker = RenameOwidPagesWorker(
         job_id=job_id,

--- a/src/main_app/jobs_workers/workers_list.py
+++ b/src/main_app/jobs_workers/workers_list.py
@@ -1,7 +1,7 @@
 from ..public_jobs_workers.copy_svg_langs.worker import copy_svg_langs_worker_entry
 from ..public_jobs_workers.fix_nested_jobs.worker import fix_nested_jobs_worker_entry
 from .add_svglanguages_template import add_svglanguages_template_to_templates
-from .collect_main_files_worker import collect_main_files_for_templates
+from .collect_main_files_worker import collect_main_files_for_templates, collect_main_files_for_templates_with_args
 from .create_owid_pages import create_owid_pages_for_templates
 from .crop_main_files import crop_main_files_for_templates
 from .download_main_files_worker import download_main_files_for_templates
@@ -21,6 +21,10 @@ jobs_targets = {
     "rename_owid_pages": rename_owid_pages_for_templates,
     "add_svglanguages_template": add_svglanguages_template_to_templates,
     "download_main_files": download_main_files_for_templates,
+}
+
+jobs_targets_with_args = {
+    "collect_main_files": collect_main_files_for_templates_with_args,
 }
 
 
@@ -60,6 +64,7 @@ JOB_TYPE_LIST_TEMPLATES_PUBLIC = {
 
 __all__ = [
     "jobs_targets",
+    "jobs_targets_with_args",
     "jobs_targets_public",
     "JOB_TYPE_TEMPLATES",
     "JOB_TYPE_LIST_TEMPLATES",

--- a/src/main_app/jobs_workers/workers_list.py
+++ b/src/main_app/jobs_workers/workers_list.py
@@ -1,7 +1,7 @@
 from ..public_jobs_workers.copy_svg_langs.worker import copy_svg_langs_worker_entry
 from ..public_jobs_workers.fix_nested_jobs.worker import fix_nested_jobs_worker_entry
 from .add_svglanguages_template import add_svglanguages_template_to_templates
-from .collect_main_files_worker import collect_main_files_for_templates, collect_main_files_for_templates_with_args
+from .collect_main_files_worker import collect_main_files_for_templates
 from .create_owid_pages import create_owid_pages_for_templates
 from .crop_main_files import crop_main_files_for_templates
 from .download_main_files_worker import download_main_files_for_templates
@@ -21,10 +21,6 @@ jobs_targets = {
     "rename_owid_pages": rename_owid_pages_for_templates,
     "add_svglanguages_template": add_svglanguages_template_to_templates,
     "download_main_files": download_main_files_for_templates,
-}
-
-jobs_targets_with_args = {
-    "collect_main_files": collect_main_files_for_templates_with_args,
 }
 
 
@@ -64,7 +60,6 @@ JOB_TYPE_LIST_TEMPLATES_PUBLIC = {
 
 __all__ = [
     "jobs_targets",
-    "jobs_targets_with_args",
     "jobs_targets_public",
     "JOB_TYPE_TEMPLATES",
     "JOB_TYPE_LIST_TEMPLATES",

--- a/src/main_app/public_jobs_workers/copy_svg_langs/worker.py
+++ b/src/main_app/public_jobs_workers/copy_svg_langs/worker.py
@@ -72,10 +72,10 @@ class CopySvgLangsWorker(BaseJobWorker):
 # --- main pipeline --------------------------------------------
 def copy_svg_langs_worker_entry(
     task_id: str,
-    args: Any,
     user: Dict[str, str] | None,
     *,
     cancel_event: threading.Event | None = None,
+    args: Any = None,
 ) -> None:
     """Entry point for the background job."""
     worker = CopySvgLangsWorker(

--- a/src/main_app/public_jobs_workers/fix_nested_jobs/worker.py
+++ b/src/main_app/public_jobs_workers/fix_nested_jobs/worker.py
@@ -72,10 +72,10 @@ class FixNestedJobsWorker(BaseJobWorker):
 # --- main pipeline --------------------------------------------
 def fix_nested_jobs_worker_entry(
     task_id: str,
-    args: Any,
     user: Dict[str, str] | None,
     *,
     cancel_event: threading.Event | None = None,
+    args: Any = None,
 ) -> None:
     """Entry point for the background job."""
 

--- a/src/templates/admins/jobs_templates/collect_main_files/list.html
+++ b/src/templates/admins/jobs_templates/collect_main_files/list.html
@@ -6,3 +6,14 @@
 {% block list_headline %}Collect Templates data Jobs{% endblock %}
 
 {% block start_confirm_message %}This will start a background job to collect templates data for all templates that don't have one. Continue?{% endblock %}
+
+{% block header_actions %}
+<form method="post" action="{{ url_for('admin.jobs.start_job_with_args', job_type=job_type) }}" class="d-inline">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+    <input type="hidden" name="update_all" value="true" />
+    <button type="submit" class="btn btn-outline-warning"
+        onclick="return confirm('This will update ALL template data (including those already collected). This may take a long time. Continue?');">
+        <i class="bi bi-arrow-repeat"></i> Update All
+    </button>
+</form>
+{% endblock %}

--- a/tests/unit/jobs_workers/test_jobs_worker.py
+++ b/tests/unit/jobs_workers/test_jobs_worker.py
@@ -125,7 +125,7 @@ def test_runner_calls_target_and_cleans_up():
 
     _runner(job_id, user, event, mock_target, flask_app)
 
-    mock_target.assert_called_once_with(job_id, user, cancel_event=event)
+    mock_target.assert_called_once_with(job_id, user, cancel_event=event, args=None)
     flask_app.app_context.assert_called_once()
     # After runner finishes, event should be popped from CANCEL_EVENTS
     assert jobs_worker.get_jobs_cancel_event(job_id) is None


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @MrIbrahem :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

Adds a new "Update All" option to the Collect Templates data background job that allows updating **all** template data, not just templates missing data.

### Changes:
- **Worker**: Added `update_all` flag to `CollectMainFilesWorker` that bypasses the `already_had_main_file` filter, processing all templates regardless of whether they already have `main_file`, `last_world_file`, and `source` set.
- **Entry point**: Added `collect_main_files_for_templates_with_args` function that accepts an `args` dict and parses `update_all` from it.
- **Registry**: Added `jobs_targets_with_args` dict in `workers_list.py` for args-based admin job targets. Updated `start_job_with_args` in `jobs_worker.py` to check this dict first.
- **UI**: Added an "Update All" button (with warning confirmation) to the collect_main_files jobs list page, using the existing `start_with_args` route.

### Behavior:
- **Default (Start New Job button)**: Still only processes templates missing data (unchanged behavior).
- **Update All button**: Processes ALL templates, re-fetching and updating their `main_file`, `last_world_file`, and `source` from wikitext."