### PR TITLE
feat: add update_owid_charts background job

### DIFF
--- a/src/main_app/__init__.py
+++ b/src/main_app/__init__.py
@@ -22,7 +22,8 @@ from .app_routes import (
 )
 from .core.cookies import CookieHeaderClient
 from .db import init_db
-from .extensions import db as _db, migrate
+from .extensions import db as _db
+from .extensions import migrate
 from .su_services.users_service import context_user
 from .utils import format_stage_timestamp, short_url
 

--- a/src/main_app/app_routes/admin/sidebar.py
+++ b/src/main_app/app_routes/admin/sidebar.py
@@ -149,6 +149,15 @@ def create_side(active_route, path: str | None = None):
                 icon="bi-download",
                 disabled=True,
             ),
+            SidebarItem(
+                id="update_owid_charts",
+                admin=1,
+                href=_safe_url_for(
+                    "admin.jobs.jobs_list", "/admin/jobs/update_owid_charts", job_type="update_owid_charts"
+                ),
+                title="Update OWID Charts",
+                icon="bi-arrow-repeat",
+            ),
         ],
         "Settings": [
             SidebarItem(

--- a/src/main_app/config/flask_config.py
+++ b/src/main_app/config/flask_config.py
@@ -1,6 +1,7 @@
 """Application configuration helpers."""
 
 from __future__ import annotations
+
 from urllib.parse import quote_plus
 
 from sqlalchemy import URL

--- a/src/main_app/config/main_settings.py
+++ b/src/main_app/config/main_settings.py
@@ -6,16 +6,15 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
-from .classes import (
+from .classes import (  # CorsConfig,
     CookieConfig,
-    # CorsConfig,
     DbConfig,
+    JobsConfig,
     OAuthConfig,
     Paths,
     SecurityConfig,
     SessionConfig,
     Settings,
-    JobsConfig,
 )
 
 # --- Helper Functions ---

--- a/src/main_app/jobs_workers/update_owid_charts/worker.py
+++ b/src/main_app/jobs_workers/update_owid_charts/worker.py
@@ -1,0 +1,277 @@
+"""
+Worker module for update_owid_charts.
+
+For every chart in the ``owid_charts`` table:
+  1. Fetch ``https://ourworldindata.org/grapher/{slug}.metadata.json``
+  2. Find the first column entry that has a ``timespan`` field
+     (format ``"YYYY-YYYY"`` or ``"YYYY"``)
+  3. Parse ``min_time``, ``max_time``, and ``len_years`` from the timespan
+  4. If any of those three values differ from the DB record → update
+
+Skipped reasons:
+  - ``no_timespan``  – no column with a ``timespan`` key was found in the JSON
+  - ``no_change``    – fetched values are identical to current DB values
+  - ``fetch_error``  – HTTP / network / JSON-decode error
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+import requests
+
+from ...db.services import owid_charts_service
+from ...db.models.owid_charts import OwidChartRecord
+from ..base_worker import BaseJobWorker
+
+logger = logging.getLogger(__name__)
+
+METADATA_URL = "https://ourworldindata.org/grapher/{slug}.metadata.json"
+
+# Seconds to wait for each HTTP request
+REQUEST_TIMEOUT = 15
+
+
+# ---------------------------------------------------------------------------
+# Timespan helpers
+# ---------------------------------------------------------------------------
+
+def _parse_timespan(timespan: str) -> tuple[int, int, int] | None:
+    """Parse a ``"YYYY-YYYY"`` or ``"YYYY"`` timespan string.
+
+    Returns ``(min_time, max_time, len_years)`` or ``None`` if unparseable.
+    """
+    parts = timespan.strip().split("-")
+    try:
+        if len(parts) == 2:  # "2000-2022"
+            min_t = int(parts[0])
+            max_t = int(parts[1])
+        elif len(parts) == 1:  # single year "2022"
+            min_t = max_t = int(parts[0])
+        else:
+            return None
+    except ValueError:
+        return None
+
+    len_y = max_t - min_t + 1
+    return min_t, max_t, len_y
+
+
+def _first_timespan(columns: dict) -> str | None:
+    """Return the first ``timespan`` value found among the column entries."""
+    for col_data in columns.values():
+        if isinstance(col_data, dict) and "timespan" in col_data:
+            return col_data["timespan"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Per-chart result dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ChartUpdateInfo:
+    chart_id: int
+    slug: str
+    status: str = "pending"   # updated | skipped | failed
+    skip_reason: str | None = None
+    error: str | None = None
+    timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
+
+    # old values (before update)
+    old_min_time: int | None = None
+    old_max_time: int | None = None
+    old_len_years: int | None = None
+
+    # new values (from API)
+    new_min_time: int | None = None
+    new_max_time: int | None = None
+    new_len_years: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chart_id": self.chart_id,
+            "slug": self.slug,
+            "status": self.status,
+            "skip_reason": self.skip_reason,
+            "error": self.error,
+            "timestamp": self.timestamp,
+            "old_min_time": self.old_min_time,
+            "old_max_time": self.old_max_time,
+            "old_len_years": self.old_len_years,
+            "new_min_time": self.new_min_time,
+            "new_max_time": self.new_max_time,
+            "new_len_years": self.new_len_years,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+class UpdateOwidChartsWorker(BaseJobWorker):
+    """Refresh ``min_time`` / ``max_time`` / ``len_years`` for every OWID chart."""
+
+    def get_job_type(self) -> str:
+        return "update_owid_charts"
+
+    def get_initial_result(self) -> Dict[str, Any]:
+        return {
+            "status": "pending",
+            "started_at": datetime.now().isoformat(),
+            "completed_at": None,
+            "cancelled_at": None,
+            "summary": {
+                "total": 0,
+                "processed": 0,
+                "updated": 0,
+                "skipped": 0,
+                "failed": 0,
+            },
+            "charts_processed": [],
+        }
+
+    # ------------------------------------------------------------------
+    # Per-chart processing
+    # ------------------------------------------------------------------
+
+    def _fetch_metadata(self, slug: str) -> dict | None:
+        """Fetch the OWID chart metadata JSON. Returns the parsed dict or None."""
+        url = METADATA_URL.format(slug=slug)
+        try:
+            resp = requests.get(url, timeout=REQUEST_TIMEOUT)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            logger.warning(f"Job {self.job_id}: Failed to fetch metadata for '{slug}': {exc}")
+            return None
+
+    def _process_chart(self, chart: OwidChartRecord) -> None:
+        info = ChartUpdateInfo(
+            chart_id=chart.chart_id,
+            slug=chart.slug,
+            old_min_time=chart.min_time,
+            old_max_time=chart.max_time,
+            old_len_years=chart.len_years,
+        )
+
+        # 1. Fetch metadata
+        metadata = self._fetch_metadata(chart.slug)
+        if metadata is None:
+            info.status = "failed"
+            info.error = "Could not fetch metadata JSON"
+            self.result["summary"]["failed"] += 1
+            self.result["charts_processed"].append(info.to_dict())
+            return
+
+        # 2. Find a timespan
+        columns = metadata.get("columns", {})
+        timespan_raw = _first_timespan(columns)
+
+        if not timespan_raw:
+            info.status = "skipped"
+            info.skip_reason = "no_timespan"
+            self.result["summary"]["skipped"] += 1
+            self.result["charts_processed"].append(info.to_dict())
+            return
+
+        # 3. Parse timespan
+        parsed = _parse_timespan(timespan_raw)
+        if parsed is None:
+            info.status = "failed"
+            info.error = f"Could not parse timespan: '{timespan_raw}'"
+            self.result["summary"]["failed"] += 1
+            self.result["charts_processed"].append(info.to_dict())
+            return
+
+        min_t, max_t, len_y = parsed
+        info.new_min_time = min_t
+        info.new_max_time = max_t
+        info.new_len_years = len_y
+
+        # 4. Compare — skip if nothing changed
+        if min_t == chart.min_time and max_t == chart.max_time and len_y == chart.len_years:
+            info.status = "skipped"
+            info.skip_reason = "no_change"
+            self.result["summary"]["skipped"] += 1
+            self.result["charts_processed"].append(info.to_dict())
+            return
+
+        # 5. Update DB
+        try:
+            owid_charts_service.update_chart_data(
+                chart.chart_id,
+                {
+                    "min_time": min_t,
+                    "max_time": max_t,
+                    "len_years": len_y,
+                },
+            )
+            info.status = "updated"
+            self.result["summary"]["updated"] += 1
+        except Exception as exc:
+            logger.exception(f"Job {self.job_id}: DB update failed for chart '{chart.slug}'")
+            info.status = "failed"
+            info.error = str(exc)
+            self.result["summary"]["failed"] += 1
+
+        self.result["charts_processed"].append(info.to_dict())
+
+    # ------------------------------------------------------------------
+    # BaseJobWorker.process
+    # ------------------------------------------------------------------
+
+    def process(self) -> Dict[str, Any]:
+        charts = owid_charts_service.list_charts()
+        total = len(charts)
+        self.result["summary"]["total"] = total
+        logger.info(f"Job {self.job_id}: Found {total} charts to process")
+
+        per_item = self.get_priority(total)
+
+        for n, chart in enumerate(charts, start=1):
+            if self.is_cancelled():
+                break
+
+            logger.info(f"Job {self.job_id}: Processing {n}/{total}: {chart.slug}")
+            self._process_chart(chart)
+            self.result["summary"]["processed"] += 1
+
+            if n == 1 or n % per_item == 0:
+                self._save_progress()
+
+        if self.result.get("status") in ("pending", "running"):
+            self.result["status"] = "completed"
+
+        return self.result
+
+
+# ---------------------------------------------------------------------------
+# Entry-point (called by the thread runner)
+# ---------------------------------------------------------------------------
+
+def update_owid_charts_worker_entry(
+    job_id: int,
+    user: Dict[str, Any] | None = None,
+    *,
+    cancel_event: threading.Event | None = None,
+    args: Dict[str, Any] | None = None,
+) -> None:
+    """Background worker entry-point for update_owid_charts."""
+    logger.info(f"Starting job {job_id}: update OWID charts timespan data")
+    worker = UpdateOwidChartsWorker(
+        job_id=job_id,
+        user=user,
+        cancel_event=cancel_event,
+    )
+    worker.run()
+
+
+__all__ = [
+    "UpdateOwidChartsWorker",
+    "update_owid_charts_worker_entry",
+]

--- a/src/main_app/jobs_workers/update_owid_charts/worker.py
+++ b/src/main_app/jobs_workers/update_owid_charts/worker.py
@@ -168,7 +168,12 @@ class UpdateOwidChartsWorker(BaseJobWorker):
             info.status = "failed"
             info.error = "Could not fetch metadata JSON"
             self.result["summary"]["failed"] += 1
-            self.result["charts_processed"].append(info.to_dict())
+            # self.result["charts_processed"].append(info.to_dict())
+            self.result["charts_processed"].append({
+                "status": "failed",
+                "slug": chart.slug,
+                "error": "Could not fetch metadata JSON",
+            })
             return
 
         # 2. Find a timespan
@@ -179,7 +184,12 @@ class UpdateOwidChartsWorker(BaseJobWorker):
             info.status = "skipped"
             info.skip_reason = "no_timespan"
             self.result["summary"]["skipped"] += 1
-            self.result["charts_processed"].append(info.to_dict())
+            # self.result["charts_processed"].appenkd(info.to_dict())
+            self.result["charts_processed"].append({
+                "status": "skipped",
+                "slug": chart.slug,
+                "skip_reason": "no_timespan",
+            })
             return
 
         # 3. Parse timespan
@@ -188,7 +198,12 @@ class UpdateOwidChartsWorker(BaseJobWorker):
             info.status = "failed"
             info.error = f"Could not parse timespan: '{timespan_raw}'"
             self.result["summary"]["failed"] += 1
-            self.result["charts_processed"].append(info.to_dict())
+            # self.result["charts_processed"].append(info.to_dict())
+            self.result["charts_processed"].append({
+                "status": "failed",
+                "slug": chart.slug,
+                "error": f"Could not parse timespan: '{timespan_raw}'",
+            })
             return
 
         min_t, max_t, len_y = parsed
@@ -201,7 +216,12 @@ class UpdateOwidChartsWorker(BaseJobWorker):
             info.status = "skipped"
             info.skip_reason = "no_change"
             self.result["summary"]["skipped"] += 1
-            self.result["charts_processed"].append(info.to_dict())
+            # self.result["charts_processed"].append(info.to_dict())
+            self.result["charts_processed"].append({
+                "status": "skipped",
+                "slug": chart.slug,
+                "skip_reason": "no_change",
+            })
             return
 
         # 5. Update DB

--- a/src/main_app/jobs_workers/update_owid_charts/worker.py
+++ b/src/main_app/jobs_workers/update_owid_charts/worker.py
@@ -24,8 +24,8 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from ...db.services import owid_charts_service
 from ...db.models.owid_charts import OwidChartRecord
+from ...db.services import owid_charts_service
 from ..base_worker import BaseJobWorker
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,7 @@ REQUEST_TIMEOUT = 15
 # ---------------------------------------------------------------------------
 # Timespan helpers
 # ---------------------------------------------------------------------------
+
 
 def _parse_timespan(timespan: str) -> tuple[int, int, int] | None:
     """Parse a ``"YYYY-YYYY"`` or ``"YYYY"`` timespan string.
@@ -73,11 +74,12 @@ def _first_timespan(columns: dict) -> str | None:
 # Per-chart result dataclass
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ChartUpdateInfo:
     chart_id: int
     slug: str
-    status: str = "pending"   # updated | skipped | failed
+    status: str = "pending"  # updated | skipped | failed
     skip_reason: str | None = None
     error: str | None = None
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
@@ -112,6 +114,7 @@ class ChartUpdateInfo:
 # ---------------------------------------------------------------------------
 # Worker
 # ---------------------------------------------------------------------------
+
 
 class UpdateOwidChartsWorker(BaseJobWorker):
     """Refresh ``min_time`` / ``max_time`` / ``len_years`` for every OWID chart."""
@@ -253,6 +256,7 @@ class UpdateOwidChartsWorker(BaseJobWorker):
 # ---------------------------------------------------------------------------
 # Entry-point (called by the thread runner)
 # ---------------------------------------------------------------------------
+
 
 def update_owid_charts_worker_entry(
     job_id: int,

--- a/src/main_app/jobs_workers/update_owid_charts/worker.py
+++ b/src/main_app/jobs_workers/update_owid_charts/worker.py
@@ -117,6 +117,10 @@ class ChartUpdateInfo:
 class UpdateOwidChartsWorker(BaseJobWorker):
     """Refresh ``min_time`` / ``max_time`` / ``len_years`` for every OWID chart."""
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session = requests.Session()
+
     def get_job_type(self) -> str:
         return "update_owid_charts"
 
@@ -144,7 +148,7 @@ class UpdateOwidChartsWorker(BaseJobWorker):
         """Fetch the OWID chart metadata JSON. Returns the parsed dict or None."""
         url = METADATA_URL.format(slug=slug)
         try:
-            resp = requests.get(url, timeout=REQUEST_TIMEOUT)
+            resp = self.session.get(url, timeout=REQUEST_TIMEOUT)
             resp.raise_for_status()
             return resp.json()
         except Exception as exc:

--- a/src/main_app/jobs_workers/update_owid_charts/worker.py
+++ b/src/main_app/jobs_workers/update_owid_charts/worker.py
@@ -15,12 +15,12 @@ Skipped reasons:
 """
 
 from __future__ import annotations
-
+import re
 import logging
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import requests
 
@@ -46,15 +46,13 @@ def _parse_timespan(timespan: str) -> tuple[int, int, int] | None:
 
     Returns ``(min_time, max_time, len_years)`` or ``None`` if unparseable.
     """
-    parts = timespan.strip().split("-")
+
+    match = re.match(r"^(-?\d+)(?:-(-?\d+))?$", timespan.strip())
+    if not match:
+        return None
     try:
-        if len(parts) == 2:  # "2000-2022"
-            min_t = int(parts[0])
-            max_t = int(parts[1])
-        elif len(parts) == 1:  # single year "2022"
-            min_t = max_t = int(parts[0])
-        else:
-            return None
+        min_t = int(match.group(1))
+        max_t = int(match.group(2)) if match.group(2) is not None else min_t
     except ValueError:
         return None
 

--- a/src/main_app/jobs_workers/workers_list.py
+++ b/src/main_app/jobs_workers/workers_list.py
@@ -7,6 +7,7 @@ from .crop_main_files import crop_main_files_for_templates
 from .download_main_files_worker import download_main_files_for_templates
 from .fix_nested_main_files_worker import fix_nested_main_files_for_templates
 from .rename_owid_pages import rename_owid_pages_for_templates
+from .update_owid_charts.worker import update_owid_charts_worker_entry
 
 jobs_targets_public = {
     "copy_svg_langs": copy_svg_langs_worker_entry,
@@ -21,6 +22,7 @@ jobs_targets = {
     "rename_owid_pages": rename_owid_pages_for_templates,
     "add_svglanguages_template": add_svglanguages_template_to_templates,
     "download_main_files": download_main_files_for_templates,
+    "update_owid_charts": update_owid_charts_worker_entry,
 }
 
 
@@ -32,6 +34,7 @@ JOB_TYPE_TEMPLATES = {
     "fix_nested_main_files": "admins/jobs_templates/fix_nested_main_files/details.html",
     "download_main_files": "admins/jobs_templates/download_main_files/details.html",
     "add_svglanguages_template": "admins/jobs_templates/add_svglanguages_template/details.html",
+    "update_owid_charts": "admins/jobs_templates/update_owid_charts/details.html",
 }
 
 
@@ -43,6 +46,7 @@ JOB_TYPE_LIST_TEMPLATES = {
     "fix_nested_main_files": "admins/jobs_templates/fix_nested_main_files/list.html",
     "download_main_files": "admins/jobs_templates/download_main_files/list.html",
     "add_svglanguages_template": "admins/jobs_templates/add_svglanguages_template/list.html",
+    "update_owid_charts": "admins/jobs_templates/update_owid_charts/list.html",
 }
 
 

--- a/src/templates/admins/jobs_templates/update_owid_charts/details.html
+++ b/src/templates/admins/jobs_templates/update_owid_charts/details.html
@@ -1,0 +1,208 @@
+{% extends "admins/jobs_templates/base_details.html" %}
+{% from "_macros.html" import card_header %}
+
+{% set job_type = 'update_owid_charts' %}
+
+{% block detail_title %}Update OWID Charts{% endblock %}
+{% block detail_headline %}Update OWID Charts{% endblock %}
+
+{% block job_summary %}
+{% if result_data.summary %}
+<div class="row row-cols-2 row-cols-md-5 g-2 text-center mb-3">
+    <div class="col">
+        <div class="card h-100 border">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.total }}</h4>
+                <small class="text-muted">Total</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-primary">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.processed }}</h4>
+                <small>Processed</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-success">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.updated }}</h4>
+                <small>Updated</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-secondary">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.skipped }}</h4>
+                <small>Skipped</small>
+            </div>
+        </div>
+    </div>
+    <div class="col">
+        <div class="card h-100 border-danger">
+            <div class="card-body p-2">
+                <h4 class="mb-0">{{ result_data.summary.failed }}</h4>
+                <small>Failed</small>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+{% endblock %}
+
+{% block job_details %}
+
+{# ------------------------------------------------------------------ #}
+{# Updated charts — with old/new comparison                           #}
+{# ------------------------------------------------------------------ #}
+{% set updated_charts = result_data.charts_processed | selectattr("status", "equalto", "updated") | list %}
+{% if updated_charts %}
+<div class="card mb-3">
+    <div class="card-header">
+        {{ card_header("Updated Charts (" ~ updated_charts | length ~ ")") }}
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Slug</th>
+                        <th class="text-center">Old min_time</th>
+                        <th class="text-center">New min_time</th>
+                        <th class="text-center">Old max_time</th>
+                        <th class="text-center">New max_time</th>
+                        <th class="text-center">Old len_years</th>
+                        <th class="text-center">New len_years</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in updated_charts %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>
+                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}"
+                               target="_blank" rel="noopener noreferrer">
+                                {{ item.slug }}
+                            </a>
+                        </td>
+                        {# min_time #}
+                        <td class="text-center {% if item.old_min_time != item.new_min_time %}table-warning{% endif %}">
+                            {{ item.old_min_time if item.old_min_time is not none else '—' }}
+                        </td>
+                        <td class="text-center {% if item.old_min_time != item.new_min_time %}table-success{% endif %}">
+                            <strong>{{ item.new_min_time if item.new_min_time is not none else '—' }}</strong>
+                        </td>
+                        {# max_time #}
+                        <td class="text-center {% if item.old_max_time != item.new_max_time %}table-warning{% endif %}">
+                            {{ item.old_max_time if item.old_max_time is not none else '—' }}
+                        </td>
+                        <td class="text-center {% if item.old_max_time != item.new_max_time %}table-success{% endif %}">
+                            <strong>{{ item.new_max_time if item.new_max_time is not none else '—' }}</strong>
+                        </td>
+                        {# len_years #}
+                        <td class="text-center {% if item.old_len_years != item.new_len_years %}table-warning{% endif %}">
+                            {{ item.old_len_years if item.old_len_years is not none else '—' }}
+                        </td>
+                        <td class="text-center {% if item.old_len_years != item.new_len_years %}table-success{% endif %}">
+                            <strong>{{ item.new_len_years if item.new_len_years is not none else '—' }}</strong>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{# ------------------------------------------------------------------ #}
+{# Failed charts                                                        #}
+{# ------------------------------------------------------------------ #}
+{% set failed_charts = result_data.charts_processed | selectattr("status", "equalto", "failed") | list %}
+{% if failed_charts %}
+<div class="card mb-3">
+    <div class="card-header">
+        {{ card_header("Failed Charts (" ~ failed_charts | length ~ ")") }}
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Slug</th>
+                        <th>Error</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in failed_charts %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>
+                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}"
+                               target="_blank" rel="noopener noreferrer">
+                                {{ item.slug }}
+                            </a>
+                        </td>
+                        <td><span class="text-danger">{{ item.error or '—' }}</span></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{# ------------------------------------------------------------------ #}
+{# Skipped charts                                                       #}
+{# ------------------------------------------------------------------ #}
+{% set skipped_charts = result_data.charts_processed | selectattr("status", "equalto", "skipped") | list %}
+{% if skipped_charts %}
+<div class="card mb-3">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        {{ card_header("Skipped Charts (" ~ skipped_charts | length ~ ")") }}
+    </div>
+    <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-sm mb-0">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Slug</th>
+                        <th>Reason</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in skipped_charts %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>
+                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}"
+                               target="_blank" rel="noopener noreferrer">
+                                {{ item.slug }}
+                            </a>
+                        </td>
+                        <td>
+                            {% if item.skip_reason == 'no_timespan' %}
+                            <span class="badge bg-secondary">no timespan</span>
+                            {% elif item.skip_reason == 'no_change' %}
+                            <span class="badge bg-light text-dark border">no change</span>
+                            {% else %}
+                            {{ item.skip_reason or '—' }}
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% endblock %}

--- a/src/templates/admins/jobs_templates/update_owid_charts/details.html
+++ b/src/templates/admins/jobs_templates/update_owid_charts/details.html
@@ -84,8 +84,8 @@
                     <tr>
                         <td>{{ loop.index }}</td>
                         <td>
-                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}"
-                               target="_blank" rel="noopener noreferrer">
+                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}" target="_blank"
+                                rel="noopener noreferrer">
                                 {{ item.slug }}
                             </a>
                         </td>
@@ -104,10 +104,12 @@
                             <strong>{{ item.new_max_time if item.new_max_time is not none else '—' }}</strong>
                         </td>
                         {# len_years #}
-                        <td class="text-center {% if item.old_len_years != item.new_len_years %}table-warning{% endif %}">
+                        <td
+                            class="text-center {% if item.old_len_years != item.new_len_years %}table-warning{% endif %}">
                             {{ item.old_len_years if item.old_len_years is not none else '—' }}
                         </td>
-                        <td class="text-center {% if item.old_len_years != item.new_len_years %}table-success{% endif %}">
+                        <td
+                            class="text-center {% if item.old_len_years != item.new_len_years %}table-success{% endif %}">
                             <strong>{{ item.new_len_years if item.new_len_years is not none else '—' }}</strong>
                         </td>
                     </tr>
@@ -143,8 +145,8 @@
                     <tr>
                         <td>{{ loop.index }}</td>
                         <td>
-                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}"
-                               target="_blank" rel="noopener noreferrer">
+                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}" target="_blank"
+                                rel="noopener noreferrer">
                                 {{ item.slug }}
                             </a>
                         </td>
@@ -182,8 +184,8 @@
                     <tr>
                         <td>{{ loop.index }}</td>
                         <td>
-                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}"
-                               target="_blank" rel="noopener noreferrer">
+                            <a href="https://ourworldindata.org/grapher/{{ item.slug }}" target="_blank"
+                                rel="noopener noreferrer">
                                 {{ item.slug }}
                             </a>
                         </td>

--- a/src/templates/admins/jobs_templates/update_owid_charts/list.html
+++ b/src/templates/admins/jobs_templates/update_owid_charts/list.html
@@ -1,0 +1,20 @@
+{% extends "admins/jobs_templates/base_list.html" %}
+
+{% set job_type = 'update_owid_charts' %}
+
+{% block list_title %}Update OWID Charts{% endblock %}
+{% block list_headline %}Update OWID Charts{% endblock %}
+
+{% block start_confirm_message %}This will fetch metadata from ourworldindata.org for every chart and update min_time / max_time / len_years where changed. Continue?{% endblock %}
+{% block start_icon %}bi-arrow-repeat{% endblock %}
+{% block start_text %}Start New Job{% endblock %}
+
+{% block list_info %}
+<div class="alert alert-info mb-3">
+    <i class="bi bi-info-circle"></i>
+    For each chart in the database this job fetches
+    <code>https://ourworldindata.org/grapher/{slug}.metadata.json</code>
+    and updates <strong>min_time</strong>, <strong>max_time</strong>, and
+    <strong>len_years</strong> when the timespan has changed.
+</div>
+{% endblock %}

--- a/src/templates/admins/jobs_templates/update_owid_charts/list.html
+++ b/src/templates/admins/jobs_templates/update_owid_charts/list.html
@@ -5,7 +5,8 @@
 {% block list_title %}Update OWID Charts{% endblock %}
 {% block list_headline %}Update OWID Charts{% endblock %}
 
-{% block start_confirm_message %}This will fetch metadata from ourworldindata.org for every chart and update min_time / max_time / len_years where changed. Continue?{% endblock %}
+{% block start_confirm_message %}This will fetch metadata from ourworldindata.org for every chart and update min_time /
+max_time / len_years where changed. Continue?{% endblock %}
 {% block start_icon %}bi-arrow-repeat{% endblock %}
 {% block start_text %}Start New Job{% endblock %}
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @MrIbrahem :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro autonomous agent](https://kiro.dev/autonomous-agent)</sub>

---
## Summary

New background job that refreshes `min_time`, `max_time`, and `len_years` for every chart in the `owid_charts` table by fetching the OWID metadata API.

### What it does
- Iterates all charts in the DB
- Fetches `https://ourworldindata.org/grapher/{slug}.metadata.json` for each
- Finds the first column entry that contains a `timespan` field (format `YYYY-YYYY` or `YYYY`)
- Parses `min_time`, `max_time`, and `len_years` from the timespan
- Updates the DB record only when at least one value has changed
- Skips with reason `no_timespan` (no column has a timespan) or `no_change` (values already match)

### Files added / changed
| File | Change |
|---|---|
| `src/main_app/jobs_workers/update_owid_charts/worker.py` | New worker (`UpdateOwidChartsWorker` + entry function) |
| `src/main_app/jobs_workers/update_owid_charts/__init__.py` | Package init |
| `src/main_app/jobs_workers/workers_list.py` | Registered `update_owid_charts` in all three dicts |
| `src/templates/admins/jobs_templates/update_owid_charts/list.html` | Job list page |
| `src/templates/admins/jobs_templates/update_owid_charts/details.html` | Job detail page |

### Details template sections
1. **Summary cards** — Total / Processed / Updated / Skipped / Failed
2. **Updated Charts** — table with old/new columns for `min_time`, `max_time`, `len_years`; changed cells highlighted yellow (old) → green (new)
3. **Failed Charts** — slug + error message
4. **Skipped Charts** — slug + badge (`no timespan` or `no change`)

### How to trigger
```
POST /admin/jobs/update_owid_charts/start
```
or via the admin UI at `/admin/jobs/update_owid_charts`.
