### PR TITLE
Restructure Admin Sidebar and Dashboard

### DIFF
--- a/src/main_app/app_routes/admin/routes.py
+++ b/src/main_app/app_routes/admin/routes.py
@@ -6,11 +6,11 @@ import logging
 
 from flask import (
     Blueprint,
-    redirect,
+    render_template,
     request,
-    url_for,
 )
 
+from ...db.services import list_jobs
 from ..admin_routes import (
     bp_coordinators,
     bp_jobs,
@@ -38,7 +38,20 @@ def inject_sidebar():
 @bp_admin.get("/")
 @admin_required
 def admin_dashboard():
-    return redirect(url_for("admin.templates.dashboard"))
+    jobs = list_jobs(limit=100)
+    job_type_names = {
+        "collect_main_files": "Collect Templates data",
+        "update_owid_charts": "Update OWID Charts",
+        "crop_main_files": "Crop Newest World Files",
+        "fix_nested_main_files": "Fix Nested Main Files",
+        "create_owid_pages": "Create OWID Pages",
+        "rename_owid_pages": "Rename OWID Pages",
+        "add_svglanguages_template": "Add {{SVGLanguages}}",
+        "download_main_files": "Download Main Files",
+        "copy_svg_langs": "Copy SVG Translation",
+        "fix_nested_jobs": "Fix Nested Tasks",
+    }
+    return render_template("admins/admin.html", jobs=jobs, job_type_names=job_type_names)
 
 
 def register_blueprints(bp_admin) -> None:

--- a/src/main_app/app_routes/admin/routes.py
+++ b/src/main_app/app_routes/admin/routes.py
@@ -11,6 +11,7 @@ from flask import (
 )
 
 from ...db.services import list_jobs
+from ...jobs_workers.workers_list import JOB_TYPE_DISPLAY_NAMES
 from ..admin_routes import (
     bp_coordinators,
     bp_jobs,
@@ -18,6 +19,7 @@ from ..admin_routes import (
     bp_settings,
     bp_templates,
 )
+from ..utils.routes_utils import get_job_detail_url
 from .admins_required import admin_required
 from .sidebar import create_side
 
@@ -39,19 +41,25 @@ def inject_sidebar():
 @admin_required
 def admin_dashboard():
     jobs = list_jobs(limit=100)
-    job_type_names = {
-        "collect_main_files": "Collect Templates data",
-        "update_owid_charts": "Update OWID Charts",
-        "crop_main_files": "Crop Newest World Files",
-        "fix_nested_main_files": "Fix Nested Main Files",
-        "create_owid_pages": "Create OWID Pages",
-        "rename_owid_pages": "Rename OWID Pages",
-        "add_svglanguages_template": "Add {{SVGLanguages}}",
-        "download_main_files": "Download Main Files",
-        "copy_svg_langs": "Copy SVG Translation",
-        "fix_nested_jobs": "Fix Nested Tasks",
-    }
-    return render_template("admins/admin.html", jobs=jobs, job_type_names=job_type_names)
+
+    # Enhance jobs with display names and detail URLs
+    enhanced_jobs = []
+    for job in jobs:
+        enhanced_jobs.append(
+            {
+                "id": job.id,
+                "status": job.status,
+                "job_type": job.job_type,
+                "display_name": JOB_TYPE_DISPLAY_NAMES.get(job.job_type, job.job_type),
+                "detail_url": get_job_detail_url(job.id, job.job_type),
+                "username": job.username,
+                "created_at": job.created_at,
+                "started_at": job.started_at,
+                "completed_at": job.completed_at,
+            }
+        )
+
+    return render_template("admins/admin.html", jobs=enhanced_jobs)
 
 
 def register_blueprints(bp_admin) -> None:

--- a/src/main_app/app_routes/admin/sidebar.py
+++ b/src/main_app/app_routes/admin/sidebar.py
@@ -49,7 +49,9 @@ def create_side(active_route, path: str | None = None):
         "Fix Nested Tasks": "bi-database",
         "Others": "bi-three-dots",
         "Tools": "bi-tools",
-        "Jobs": "bi-gear-fill",
+        "DB jobs": "bi-database-fill",
+        "Files jobs": "bi-files",
+        "OWID Templates/Pages": "bi-file-earmark-richtext",
         "Settings": "bi-sliders",
     }
 
@@ -84,7 +86,7 @@ def create_side(active_route, path: str | None = None):
                 icon="bi-graph-up",
             ),
         ],
-        "Jobs": [
+        "DB jobs": [
             SidebarItem(
                 id="collect_main_files",
                 admin=1,
@@ -95,12 +97,44 @@ def create_side(active_route, path: str | None = None):
                 icon="bi-kanban",
             ),
             SidebarItem(
+                id="update_owid_charts",
+                admin=1,
+                href=_safe_url_for(
+                    "admin.jobs.jobs_list", "/admin/jobs/update_owid_charts", job_type="update_owid_charts"
+                ),
+                title="Update OWID Charts",
+                icon="bi-arrow-repeat",
+            ),
+        ],
+        "Files jobs": [
+            SidebarItem(
                 id="crop_main_files",
                 admin=1,
                 href=_safe_url_for("admin.jobs.jobs_list", "/admin/jobs/crop_main_files", job_type="crop_main_files"),
                 title="Crop Newest World Files",
                 icon="bi-crop",
             ),
+            SidebarItem(
+                id="fix_nested_main_files",
+                admin=1,
+                href=_safe_url_for(
+                    "admin.jobs.jobs_list", "/admin/jobs/fix_nested_main_files", job_type="fix_nested_main_files"
+                ),
+                title="Fix Nested Main Files",
+                icon="bi-tools",
+            ),
+            SidebarItem(
+                id="download_main_files",
+                admin=1,
+                href=_safe_url_for(
+                    "admin.jobs.jobs_list", "/admin/jobs/download_main_files", job_type="download_main_files"
+                ),
+                title="Download Main Files",
+                icon="bi-download",
+                disabled=True,
+            ),
+        ],
+        "OWID Templates/Pages": [
             SidebarItem(
                 id="create_owid_pages",
                 admin=1,
@@ -129,34 +163,6 @@ def create_side(active_route, path: str | None = None):
                 ),
                 title="Add {{SVGLanguages}}",
                 icon="bi-file-earmark-text",
-            ),
-            SidebarItem(
-                id="fix_nested_main_files",
-                admin=1,
-                href=_safe_url_for(
-                    "admin.jobs.jobs_list", "/admin/jobs/fix_nested_main_files", job_type="fix_nested_main_files"
-                ),
-                title="Fix Nested Main Files",
-                icon="bi-tools",
-            ),
-            SidebarItem(
-                id="download_main_files",
-                admin=1,
-                href=_safe_url_for(
-                    "admin.jobs.jobs_list", "/admin/jobs/download_main_files", job_type="download_main_files"
-                ),
-                title="Download Main Files",
-                icon="bi-download",
-                disabled=True,
-            ),
-            SidebarItem(
-                id="update_owid_charts",
-                admin=1,
-                href=_safe_url_for(
-                    "admin.jobs.jobs_list", "/admin/jobs/update_owid_charts", job_type="update_owid_charts"
-                ),
-                title="Update OWID Charts",
-                icon="bi-arrow-repeat",
             ),
         ],
         "Settings": [

--- a/src/main_app/app_routes/utils/routes_utils.py
+++ b/src/main_app/app_routes/utils/routes_utils.py
@@ -5,7 +5,10 @@ import logging
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from flask import url_for
+
 from ...db.models import UserTokenRecord
+from ...jobs_workers.workers_list import JOB_TYPE_TEMPLATES_PUBLIC
 
 logger = logging.getLogger(__name__)
 
@@ -99,3 +102,10 @@ def format_task(task: dict) -> dict:
         "results": results,
         "stages": stages,
     }
+
+
+def get_job_detail_url(job_id: int, job_type: str) -> str:
+    """Returns the correct job detail URL based on job type."""
+    if job_type in JOB_TYPE_TEMPLATES_PUBLIC:
+        return url_for("public_jobs.job_detail", job_type=job_type, job_id=job_id)
+    return url_for("admin.jobs.job_detail", job_type=job_type, job_id=job_id)

--- a/src/main_app/jobs_workers/workers_list.py
+++ b/src/main_app/jobs_workers/workers_list.py
@@ -62,6 +62,20 @@ JOB_TYPE_LIST_TEMPLATES_PUBLIC = {
 }
 
 
+JOB_TYPE_DISPLAY_NAMES = {
+    "collect_main_files": "Collect Templates data",
+    "update_owid_charts": "Update OWID Charts",
+    "crop_main_files": "Crop Newest World Files",
+    "fix_nested_main_files": "Fix Nested Main Files",
+    "create_owid_pages": "Create OWID Pages",
+    "rename_owid_pages": "Rename OWID Pages",
+    "add_svglanguages_template": "Add {{SVGLanguages}}",
+    "download_main_files": "Download Main Files",
+    "copy_svg_langs": "Copy SVG Translation",
+    "fix_nested_jobs": "Fix Nested Tasks",
+}
+
+
 __all__ = [
     "jobs_targets",
     "jobs_targets_public",
@@ -69,4 +83,5 @@ __all__ = [
     "JOB_TYPE_LIST_TEMPLATES",
     "JOB_TYPE_TEMPLATES_PUBLIC",
     "JOB_TYPE_LIST_TEMPLATES_PUBLIC",
+    "JOB_TYPE_DISPLAY_NAMES",
 ]

--- a/src/templates/admins/admin.html
+++ b/src/templates/admins/admin.html
@@ -42,8 +42,8 @@
                         <td>{{ job.display_name }}</td>
                         <td>{{ job.username if job.username else '-' }}</td>
                         <td>{{ job.created_at.strftime('%Y-%m-%d %H:%M:%S') if job.created_at else '-' }}</td>
-                        <td>{{ job.started_at.strftime('%H:%M:%S') if job.started_at else '-' }}</td>
-                        <td>{{ job.completed_at.strftime('%H:%M:%S') if job.completed_at else '-' }}</td>
+                        <td>{{ job.started_at.strftime('%Y-%m-%d %H:%M:%S') if job.started_at else '-' }}</td>
+                        <td>{{ job.completed_at.strftime('%Y-%m-%d %H:%M:%S') if job.completed_at else '-' }}</td>
                         <td class="text-center">
                             <a href="{{ job.detail_url }}" class="btn btn-outline-primary btn-sm">
                                 <i class="bi bi-eye"></i> View

--- a/src/templates/admins/admin.html
+++ b/src/templates/admins/admin.html
@@ -39,23 +39,15 @@
                             <span class="badge bg-secondary">{{ job.status }}</span>
                             {% endif %}
                         </td>
-                        <td>{{ job_type_names.get(job.job_type, job.job_type) }}</td>
+                        <td>{{ job.display_name }}</td>
                         <td>{{ job.username if job.username else '-' }}</td>
                         <td>{{ job.created_at.strftime('%Y-%m-%d %H:%M:%S') if job.created_at else '-' }}</td>
                         <td>{{ job.started_at.strftime('%H:%M:%S') if job.started_at else '-' }}</td>
                         <td>{{ job.completed_at.strftime('%H:%M:%S') if job.completed_at else '-' }}</td>
                         <td class="text-center">
-                            {% if job.job_type in ['copy_svg_langs', 'fix_nested_jobs'] %}
-                                <a href="{{ url_for('public_jobs.job_detail', job_type=job.job_type, job_id=job.id) }}"
-                                   class="btn btn-outline-primary btn-sm">
-                                    <i class="bi bi-eye"></i> View
-                                </a>
-                            {% else %}
-                                <a href="{{ url_for('admin.jobs.job_detail', job_type=job.job_type, job_id=job.id) }}"
-                                   class="btn btn-outline-primary btn-sm">
-                                    <i class="bi bi-eye"></i> View
-                                </a>
-                            {% endif %}
+                            <a href="{{ job.detail_url }}" class="btn btn-outline-primary btn-sm">
+                                <i class="bi bi-eye"></i> View
+                            </a>
                         </td>
                     </tr>
                     {% endfor %}

--- a/src/templates/admins/admin.html
+++ b/src/templates/admins/admin.html
@@ -1,16 +1,66 @@
 {% extends "admins/base1.html" %}
 
-{% block title %}Admin Dashboard · Copy SVG Translation{% endblock %}
+{% block title %}Recent Jobs · Copy SVG Translation{% endblock %}
 
 {% block contents %}
 <div class="card">
     <div class="card-header">
-        <h3 class="headline">Tasks</h3>
-
+        <h3 class="headline mb-0">Recent Jobs</h3>
     </div>
     <div class="card-body">
-
-        <div class="table-responsive">
+        <div class="table-responsive shadow-sm">
+            <table class="table table-striped table-hover align-middle mb-0 DataTable">
+                <thead>
+                    <tr>
+                        <th scope="col" style="width: 5%">#</th>
+                        <th scope="col" style="width: 5%">ID</th>
+                        <th scope="col" style="width: 10%">Status</th>
+                        <th scope="col" style="width: 15%">Jobs type</th>
+                        <th scope="col" style="width: 10%">User</th>
+                        <th scope="col" style="width: 15%">Created</th>
+                        <th scope="col" style="width: 10%">Started</th>
+                        <th scope="col" style="width: 10%">Completed</th>
+                        <th scope="col" class="text-center" style="width: 10%">Details</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for job in jobs %}
+                    <tr>
+                        <td>{{ loop.index }}</td>
+                        <td>{{ job.id }}</td>
+                        <td>
+                            {% if job.status == 'completed' %}
+                            <span class="badge bg-success">{{ job.status }}</span>
+                            {% elif job.status == 'failed' %}
+                            <span class="badge bg-danger">{{ job.status }}</span>
+                            {% elif job.status == 'running' %}
+                            <span class="badge bg-primary">{{ job.status }}</span>
+                            {% else %}
+                            <span class="badge bg-secondary">{{ job.status }}</span>
+                            {% endif %}
+                        </td>
+                        <td>{{ job_type_names.get(job.job_type, job.job_type) }}</td>
+                        <td>{{ job.username if job.username else '-' }}</td>
+                        <td>{{ job.created_at.strftime('%Y-%m-%d %H:%M:%S') if job.created_at else '-' }}</td>
+                        <td>{{ job.started_at.strftime('%H:%M:%S') if job.started_at else '-' }}</td>
+                        <td>{{ job.completed_at.strftime('%H:%M:%S') if job.completed_at else '-' }}</td>
+                        <td class="text-center">
+                            {% if job.job_type in ['copy_svg_langs', 'fix_nested_jobs'] %}
+                                <a href="{{ url_for('public_jobs.job_detail', job_type=job.job_type, job_id=job.id) }}"
+                                   class="btn btn-outline-primary btn-sm">
+                                    <i class="bi bi-eye"></i> View
+                                </a>
+                            {% else %}
+                                <a href="{{ url_for('admin.jobs.job_detail', job_type=job.job_type, job_id=job.id) }}"
+                                   class="btn btn-outline-primary btn-sm">
+                                    <i class="bi bi-eye"></i> View
+                                </a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
     </div>
 </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,7 @@ def disable_network(mocker):
 
 
 @pytest.fixture
-def app() -> Generator[Flask, Any]:
+def app() -> Generator[Flask, Any, None]:
     """Create and configure a test Flask application.
 
     Yields:

--- a/tests/unit/app_routes/admin/test_sidebar.py
+++ b/tests/unit/app_routes/admin/test_sidebar.py
@@ -81,8 +81,12 @@ def test_create_side_with_active_item():
 def test_sidebar_contains_jobs_section():
     """Test that sidebar contains the Jobs section."""
     result = sidebar.create_side("collect_main_files")
-    assert "Jobs" in result
-    assert "bi-gear-fill" in result
+    assert "DB jobs" in result
+    assert "Files jobs" in result
+    assert "OWID Templates/Pages" in result
+    assert "bi-database-fill" in result
+    assert "bi-files" in result
+    assert "bi-file-earmark-richtext" in result
 
 
 def test_sidebar_contains_collect_main_files_job_link():

--- a/tests/unit/app_routes/utils/test_get_job_detail_url.py
+++ b/tests/unit/app_routes/utils/test_get_job_detail_url.py
@@ -1,0 +1,13 @@
+import pytest
+from flask import Flask
+from src.main_app.app_routes.utils.routes_utils import get_job_detail_url
+
+def test_get_job_detail_url_public(app):
+    with app.test_request_context():
+        url = get_job_detail_url(1, "copy_svg_langs")
+        assert "/jobs/copy_svg_langs/1" in url
+
+def test_get_job_detail_url_admin(app):
+    with app.test_request_context():
+        url = get_job_detail_url(1, "collect_main_files")
+        assert "/admin/jobs/collect_main_files/1" in url


### PR DESCRIPTION
Restructured the admin sidebar to categorize background jobs into 'DB jobs', 'Files jobs', and 'OWID Templates/Pages' as requested. Replaced the default /admin/ redirect with a comprehensive 'Recent Jobs' dashboard table showing the 100 most recent tasks across all categories. The table includes columns for ID, status, job type, user, and timestamps, with direct links to job details. verified the changes with a local Playwright script and updated the unit tests.

---
*PR created automatically by Jules for task [18182607899879483379](https://jules.google.com/task/18182607899879483379) started by @MrIbrahem*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard now shows a "Recent Jobs" table with status badges, job display names, user, timestamps, and a "View" button to open job details.
  * Job types now have human-readable display names.

* **Improvements**
  * Sidebar reorganized into "DB jobs", "Files jobs", and "OWID Templates/Pages" for clearer navigation.
  * Admin page title updated to "Recent Jobs · Copy SVG Translation".

* **Tests**
  * Added/updated tests for sidebar content and job-detail URL routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Mdwiki-TD/svg_translate_web/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->