### PR TITLE
Prevent Multiple Background Jobs of the Same Type from Running Simultaneously

### DIFF
--- a/src/main_app/app_routes/admin_routes/jobs.py
+++ b/src/main_app/app_routes/admin_routes/jobs.py
@@ -21,6 +21,7 @@ from flask.typing import ResponseReturnValue
 from werkzeug.wrappers.response import Response
 
 from ...config import settings
+from ...db.exceptions import JobAlreadyRunningError
 from ...db.services import (
     delete_job,
     get_job,
@@ -79,6 +80,8 @@ def _start_job(job_type: str) -> int | None:
         job_id = jobs_worker.start_job(auth_payload, job_type)
         flash(f"Job {job_id} started to {job_type.replace('_', ' ')}.", "success")
         return job_id
+    except JobAlreadyRunningError as exc:
+        flash(str(exc), "warning")
     except Exception:
         logger.exception("Failed to start job")
         flash("Failed to start job. Please try again.", "danger")
@@ -100,6 +103,8 @@ def _start_job_with_args(job_type: str, args: dict[str, Any]) -> int | None:
         job_id = jobs_worker.start_job_with_args(auth_payload, job_type, args)
         flash(f"Job {job_id} started to {job_type.replace('_', ' ')}.", "success")
         return job_id
+    except JobAlreadyRunningError as exc:
+        flash(str(exc), "warning")
     except Exception:
         logger.exception("Failed to start job")
         flash("Failed to start job. Please try again.", "danger")

--- a/src/main_app/app_routes/public_jobs.py
+++ b/src/main_app/app_routes/public_jobs.py
@@ -22,6 +22,7 @@ from flask.typing import ResponseReturnValue
 from werkzeug.wrappers.response import Response
 
 from ..config import settings
+from ..db.exceptions import JobAlreadyRunningError
 from ..db.services import (
     delete_job,
     get_job,
@@ -101,6 +102,8 @@ def _start_job(job_type: str) -> int | None:
         job_id = jobs_worker.start_job(auth_payload, job_type)
         flash(f"Job {job_id} started to {job_type.replace('_', ' ')}.", "success")
         return job_id
+    except JobAlreadyRunningError as exc:
+        flash(str(exc), "warning")
     except Exception:
         logger.exception("Failed to start job")
         flash("Failed to start job. Please try again.", "danger")
@@ -122,6 +125,8 @@ def _start_job_with_args(job_type: str, args: dict[str, Any]) -> int | None:
         job_id = jobs_worker.start_job_with_args(auth_payload, job_type, args)
         flash(f"Job {job_id} started to {job_type.replace('_', ' ')}.", "success")
         return job_id
+    except JobAlreadyRunningError as exc:
+        flash(str(exc), "warning")
     except Exception:
         logger.exception("Failed to start job")
         flash("Failed to start job. Please try again.", "danger")

--- a/src/main_app/db/exceptions.py
+++ b/src/main_app/db/exceptions.py
@@ -13,6 +13,10 @@ class UserNotFoundError(LookupError):
     """Raised when a referenced user does not exist in users."""
 
 
+class JobAlreadyRunningError(Exception):
+    """Raised when a job of the same type is already running."""
+
+
 class InsufficientDatabaseConfigError(RuntimeError):
     def __init__(self):
         msg = "DB requires database configuration; no fallback store is available."

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -11,6 +11,7 @@ from .jobs_service import (
     create_job,
     delete_job,
     get_job,
+    has_active_job,
     is_job_cancelled,
     list_jobs,
     update_job_status,
@@ -101,4 +102,5 @@ __all__ = [
     "update_job_status",
     "cancel_job",
     "is_job_cancelled",
+    "has_active_job",
 ]

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -11,7 +11,6 @@ from .jobs_service import (
     create_job,
     delete_job,
     get_job,
-    has_active_job,
     is_job_cancelled,
     list_jobs,
     update_job_status,
@@ -102,5 +101,4 @@ __all__ = [
     "update_job_status",
     "cancel_job",
     "is_job_cancelled",
-    "has_active_job",
 ]

--- a/src/main_app/db/services/jobs_service.py
+++ b/src/main_app/db/services/jobs_service.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+from sqlalchemy import text
+
 from ...extensions import db
+from ..exceptions import JobAlreadyRunningError
 from ..models.jobs import JobRecord
 
 logger = logging.getLogger(__name__)
@@ -11,16 +14,40 @@ logger = logging.getLogger(__name__)
 
 def create_job(job_type: str, username: str | None = None) -> JobRecord:
     """
-    Create a new job record.
-
-    Query to match:
-        INSERT INTO jobs (job_type, status, username) VALUES (%s, %s, %s)
-        (job_type, "pending", username),
+    Create a new job record atomically to prevent concurrent jobs of the same type.
     """
-    job = JobRecord(job_type=job_type, username=username, status="pending")
-    db.session.add(job)
+    # Use an atomic insert to prevent race conditions.
+    # This works for both MariaDB and SQLite (used in tests).
+    sql = text("""
+        INSERT INTO jobs (job_type, username, status)
+        SELECT :job_type, :username, 'pending'
+        FROM (SELECT 1) AS dummy
+        WHERE NOT EXISTS (
+            SELECT 1 FROM jobs
+            WHERE job_type = :job_type AND status IN ('pending', 'running')
+        )
+    """)
+
+    result = db.session.execute(sql, {"job_type": job_type, "username": username})
+
+    if result.rowcount == 0:
+        raise JobAlreadyRunningError(f"A job of type {job_type} is already running.")
+
     db.session.commit()
-    db.session.refresh(job)
+
+    # Get the inserted job. Since we just inserted it and it's the only active one,
+    # we can find it by querying the latest pending job of this type.
+    job = (
+        db.session.query(JobRecord)
+        .filter(JobRecord.job_type == job_type, JobRecord.status == "pending")
+        .order_by(JobRecord.id.desc())
+        .first()
+    )
+
+    if not job:
+        # This shouldn't happen if rowcount > 0, but for safety:
+        raise RuntimeError(f"Failed to retrieve newly created job of type {job_type}")
+
     return job
 
 
@@ -188,18 +215,6 @@ def is_job_cancelled(job_id: int, job_type: str) -> bool:
     return False
 
 
-def has_active_job(job_type: str) -> bool:
-    """
-    Check if there is an active (pending or running) job of the given type.
-    """
-    return (
-        db.session.query(JobRecord)
-        .filter(JobRecord.job_type == job_type, JobRecord.status.in_(["pending", "running"]))
-        .first()
-        is not None
-    )
-
-
 __all__ = [
     "create_job",
     "get_job",
@@ -208,6 +223,5 @@ __all__ = [
     "update_running_status",
     "cancel_job",
     "is_job_cancelled",
-    "has_active_job",
     "delete_job",
 ]

--- a/src/main_app/db/services/jobs_service.py
+++ b/src/main_app/db/services/jobs_service.py
@@ -188,6 +188,18 @@ def is_job_cancelled(job_id: int, job_type: str) -> bool:
     return False
 
 
+def has_active_job(job_type: str) -> bool:
+    """
+    Check if there is an active (pending or running) job of the given type.
+    """
+    return (
+        db.session.query(JobRecord)
+        .filter(JobRecord.job_type == job_type, JobRecord.status.in_(["pending", "running"]))
+        .first()
+        is not None
+    )
+
+
 __all__ = [
     "create_job",
     "get_job",
@@ -196,5 +208,6 @@ __all__ = [
     "update_running_status",
     "cancel_job",
     "is_job_cancelled",
+    "has_active_job",
     "delete_job",
 ]

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -8,9 +8,11 @@ from typing import Any, Dict
 
 from flask import Flask, current_app
 
+from ..db.exceptions import JobAlreadyRunningError
 from ..db.services import cancel_job as cancel_job_db
 from ..db.services import (
     create_job,
+    has_active_job,
 )
 from .workers_list import jobs_data, jobs_data_public
 
@@ -89,6 +91,11 @@ def start_job(user: Dict[str, Any] | None, job_type: str, args: Dict[str, Any] |
         raise ValueError(f"Unknown job type: {job_type}")
 
     username = user.get("username") if user else None
+
+    # Check for already running job of the same type
+    if has_active_job(job_type):
+        logger.warning(f"Job of type {job_type} is already running.")
+        raise JobAlreadyRunningError(f"A job of type {job_type} is already running.")
 
     # Create job record
     job = create_job(job_type, username)

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -8,11 +8,9 @@ from typing import Any, Dict
 
 from flask import Flask, current_app
 
-from ..db.exceptions import JobAlreadyRunningError
 from ..db.services import cancel_job as cancel_job_db
 from ..db.services import (
     create_job,
-    has_active_job,
 )
 from .workers_list import jobs_data, jobs_data_public
 
@@ -92,12 +90,7 @@ def start_job(user: Dict[str, Any] | None, job_type: str, args: Dict[str, Any] |
 
     username = user.get("username") if user else None
 
-    # Check for already running job of the same type
-    if has_active_job(job_type):
-        logger.warning(f"Job of type {job_type} is already running.")
-        raise JobAlreadyRunningError(f"A job of type {job_type} is already running.")
-
-    # Create job record
+    # Create job record (atomic check and create)
     job = create_job(job_type, username)
 
     cancel_event = threading.Event()

--- a/tests/integration/app_routes/admin/admin_routes/test_admin_jobs_routes.py
+++ b/tests/integration/app_routes/admin/admin_routes/test_admin_jobs_routes.py
@@ -74,7 +74,8 @@ def test_jobs_list_page_displays_jobs(admin_jobs_client, jobs_db):
     """Test that the jobs list page displays jobs."""
 
     # Create some test jobs
-    jobs_db.create("collect_main_files")
+    j1 = jobs_db.create("collect_main_files")
+    jobs_db.update_status(j1.id, "completed", job_type="collect_main_files")
     jobs_db.create("collect_main_files")
 
     response = admin_jobs_client.get("/admin/jobs/collect_main_files")
@@ -188,7 +189,8 @@ def test_jobs_list_filters_by_job_type(admin_jobs_client, jobs_db):
     """Test that the jobs list only shows collect_main_files jobs."""
 
     # Create jobs of different types
-    jobs_db.create("collect_main_files")
+    j1 = jobs_db.create("collect_main_files")
+    jobs_db.update_status(j1.id, "completed", job_type="collect_main_files")
     jobs_db.create("collect_main_files")
     jobs_db.create("other_job_type")
 
@@ -205,7 +207,8 @@ def test_fix_nested_jobs_list_page_displays_jobs(admin_jobs_client, jobs_db):
     """Test that the fix nested jobs list page displays jobs."""
 
     # Create some test jobs
-    jobs_db.create("fix_nested_main_files")
+    j1 = jobs_db.create("fix_nested_main_files")
+    jobs_db.update_status(j1.id, "completed", job_type="fix_nested_main_files")
     jobs_db.create("fix_nested_main_files")
 
     response = admin_jobs_client.get("/admin/jobs/fix_nested_main_files")
@@ -323,7 +326,8 @@ def test_fix_nested_jobs_list_filters_by_job_type(admin_jobs_client, jobs_db):
     """Test that the fix nested jobs list only shows fix_nested_main_files jobs."""
 
     # Create jobs of different types
-    jobs_db.create("fix_nested_main_files")
+    j1 = jobs_db.create("fix_nested_main_files")
+    jobs_db.update_status(j1.id, "completed", job_type="fix_nested_main_files")
     jobs_db.create("fix_nested_main_files")
     jobs_db.create("collect_main_files")
     jobs_db.create("other_job_type")
@@ -435,6 +439,7 @@ def test_delete_multiple_jobs(admin_jobs_client, jobs_db):
 
     # Create multiple jobs
     job1 = jobs_db.create("collect_main_files")
+    jobs_db.update_status(job1.id, "completed", job_type="collect_main_files")
     job2 = jobs_db.create("collect_main_files")
     job3 = jobs_db.create("fix_nested_main_files")
     assert len(jobs_db.list()) == 3
@@ -498,7 +503,8 @@ def test_download_main_files_jobs_list_page_displays_jobs(admin_jobs_client, job
     """Test that the download main files jobs list page displays jobs."""
 
     # Create some test jobs
-    jobs_db.create("download_main_files")
+    j1 = jobs_db.create("download_main_files")
+    jobs_db.update_status(j1.id, "completed", job_type="download_main_files")
     jobs_db.create("download_main_files")
 
     response = admin_jobs_client.get("/admin/jobs/download_main_files")
@@ -622,7 +628,8 @@ def test_download_main_files_jobs_list_filters_by_job_type(admin_jobs_client, jo
     """Test that the download main files jobs list only shows download_main_files jobs."""
 
     # Create jobs of different types
-    jobs_db.create("download_main_files")
+    j1 = jobs_db.create("download_main_files")
+    jobs_db.update_status(j1.id, "completed", job_type="download_main_files")
     jobs_db.create("download_main_files")
     jobs_db.create("collect_main_files")
     jobs_db.create("fix_nested_main_files")

--- a/tests/unit/jobs_workers/test_jobs_worker.py
+++ b/tests/unit/jobs_workers/test_jobs_worker.py
@@ -17,7 +17,6 @@ def mock_jobs_service_for_jobs_worker(monkeypatch: pytest.MonkeyPatch):
     """Mock jobs_service functions to avoid database calls."""
     mock_is_cancelled = MagicMock(return_value=False)
     mock_cancel_job = MagicMock(return_value=False)
-    mock_has_active_job = MagicMock(return_value=False)
     monkeypatch.setattr(
         "src.main_app.db.services.jobs_service.is_job_cancelled",
         mock_is_cancelled,
@@ -26,14 +25,9 @@ def mock_jobs_service_for_jobs_worker(monkeypatch: pytest.MonkeyPatch):
         "src.main_app.db.services.jobs_service.cancel_job",
         mock_cancel_job,
     )
-    monkeypatch.setattr(
-        "src.main_app.db.services.jobs_service.has_active_job",
-        mock_has_active_job,
-    )
     return {
         "is_job_cancelled": mock_is_cancelled,
         "cancel_job": mock_cancel_job,
-        "has_active_job": mock_has_active_job,
     }
 
 
@@ -308,18 +302,15 @@ def test_start_job_with_args_alias_works(mock_current_app, mock_thread, mock_cre
     assert thread_args[5] is args
 
 
-@patch("src.main_app.jobs_workers.jobs_worker.has_active_job")
 @patch("src.main_app.jobs_workers.jobs_worker.create_job")
 @patch("src.main_app.jobs_workers.jobs_worker.threading.Thread")
 @patch("src.main_app.jobs_workers.jobs_worker.current_app")
-def test_start_job_blocks_if_already_running(
-    mock_current_app, mock_thread, mock_create_job, mock_has_active_job, mock_jobs_service_for_jobs_worker
-):
-    """Test that start_job raises JobAlreadyRunningError if a job of the same type is active."""
-    mock_has_active_job.return_value = True
+def test_start_job_blocks_if_already_running(mock_current_app, mock_thread, mock_create_job):
+    """Test that start_job raises JobAlreadyRunningError if create_job raises it."""
+    mock_create_job.side_effect = JobAlreadyRunningError("A job of type collect_main_files is already running.")
 
     with pytest.raises(JobAlreadyRunningError, match="A job of type collect_main_files is already running."):
         jobs_worker.start_job(None, "collect_main_files")
 
-    mock_create_job.assert_not_called()
+    mock_create_job.assert_called_once()
     mock_thread.assert_not_called()

--- a/tests/unit/jobs_workers/test_jobs_worker.py
+++ b/tests/unit/jobs_workers/test_jobs_worker.py
@@ -7,15 +7,17 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.main_app.db.exceptions import JobAlreadyRunningError
 from src.main_app.db.models import JobRecord
 from src.main_app.jobs_workers import jobs_worker
 
 
 @pytest.fixture(autouse=True)
 def mock_jobs_service_for_jobs_worker(monkeypatch: pytest.MonkeyPatch):
-    """Mock jobs_service.is_job_cancelled and cancel_job to avoid database calls."""
+    """Mock jobs_service functions to avoid database calls."""
     mock_is_cancelled = MagicMock(return_value=False)
     mock_cancel_job = MagicMock(return_value=False)
+    mock_has_active_job = MagicMock(return_value=False)
     monkeypatch.setattr(
         "src.main_app.db.services.jobs_service.is_job_cancelled",
         mock_is_cancelled,
@@ -24,7 +26,15 @@ def mock_jobs_service_for_jobs_worker(monkeypatch: pytest.MonkeyPatch):
         "src.main_app.db.services.jobs_service.cancel_job",
         mock_cancel_job,
     )
-    return {"is_job_cancelled": mock_is_cancelled, "cancel_job": mock_cancel_job}
+    monkeypatch.setattr(
+        "src.main_app.db.services.jobs_service.has_active_job",
+        mock_has_active_job,
+    )
+    return {
+        "is_job_cancelled": mock_is_cancelled,
+        "cancel_job": mock_cancel_job,
+        "has_active_job": mock_has_active_job,
+    }
 
 
 @pytest.fixture(autouse=True)
@@ -296,3 +306,20 @@ def test_start_job_with_args_alias_works(mock_current_app, mock_thread, mock_cre
     mock_create_job.assert_called_once_with("collect_main_files", "alias_user")
     thread_args = mock_thread.call_args[1]["args"]
     assert thread_args[5] is args
+
+
+@patch("src.main_app.jobs_workers.jobs_worker.has_active_job")
+@patch("src.main_app.jobs_workers.jobs_worker.create_job")
+@patch("src.main_app.jobs_workers.jobs_worker.threading.Thread")
+@patch("src.main_app.jobs_workers.jobs_worker.current_app")
+def test_start_job_blocks_if_already_running(
+    mock_current_app, mock_thread, mock_create_job, mock_has_active_job, mock_jobs_service_for_jobs_worker
+):
+    """Test that start_job raises JobAlreadyRunningError if a job of the same type is active."""
+    mock_has_active_job.return_value = True
+
+    with pytest.raises(JobAlreadyRunningError, match="A job of type collect_main_files is already running."):
+        jobs_worker.start_job(None, "collect_main_files")
+
+    mock_create_job.assert_not_called()
+    mock_thread.assert_not_called()

--- a/tests/unit/services/test_jobs_service.py
+++ b/tests/unit/services/test_jobs_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from src.main_app.db.exceptions import JobAlreadyRunningError
 from src.main_app.db.models import JobRecord
 from src.main_app.db.services import jobs_service
 from src.main_app.db.services.jobs_service import (
@@ -36,6 +37,31 @@ def test_create_job_with_username():
     assert job.username == "test_user"
 
 
+def test_create_job_blocks_concurrent_active_jobs():
+    """Test that create_job raises JobAlreadyRunningError if an active job already exists."""
+    # Create first job - status is 'pending' by default
+    create_job("collect_main_files", username="user1")
+
+    # Try to create second job of same type
+    with pytest.raises(JobAlreadyRunningError, match="A job of type collect_main_files is already running."):
+        create_job("collect_main_files", username="user2")
+
+    # Update first job to 'running'
+    update_job_status(1, "running", job_type="collect_main_files")
+
+    # Try again - still blocked
+    with pytest.raises(JobAlreadyRunningError, match="A job of type collect_main_files is already running."):
+        create_job("collect_main_files", username="user3")
+
+    # Finish first job
+    update_job_status(1, "completed", job_type="collect_main_files")
+
+    # Now we can create a new one
+    job2 = create_job("collect_main_files", username="user4")
+    assert job2.id == 2
+    assert job2.username == "user4"
+
+
 def test_get_job():
     """Test retrieving a job by ID."""
     created_job = create_job("collect_main_files", username="z")
@@ -54,8 +80,10 @@ def test_get_nonexistent_job():
 
 def test_list_jobs():
     """Test listing jobs."""
-    create_job("collect_main_files", username="z")
-    create_job("collect_main_files", username="z")
+    j1 = create_job("collect_main_files", username="z")
+    update_job_status(j1.id, "completed", job_type="collect_main_files")
+    j2 = create_job("collect_main_files", username="z")
+    update_job_status(j2.id, "completed", job_type="collect_main_files")
     create_job("other_job", username="z")
 
     jobs = list_jobs()
@@ -67,7 +95,8 @@ def test_list_jobs():
 def test_list_jobs_with_limit():
     """Test listing jobs with a limit."""
     for _ in range(5):
-        create_job("collect_main_files", username="z")
+        j = create_job("collect_main_files", username="z")
+        update_job_status(j.id, "completed", job_type="collect_main_files")
 
     jobs = list_jobs(limit=2)
 
@@ -141,8 +170,10 @@ def test_delete_nonexistent_job():
 
 def test_list_jobs_filtered_by_type():
     """Test listing jobs filtered by job_type."""
-    create_job("collect_main_files", username="z")
-    create_job("collect_main_files", username="z")
+    j1 = create_job("collect_main_files", username="z")
+    update_job_status(j1.id, "completed", job_type="collect_main_files")
+    j2 = create_job("collect_main_files", username="z")
+    update_job_status(j2.id, "completed", job_type="collect_main_files")
     create_job("fix_nested_main_files", username="z")
     create_job("other_job_type", username="z")
 
@@ -164,9 +195,11 @@ def test_list_jobs_filtered_by_type():
 def test_list_jobs_filtered_with_limit():
     """Test listing jobs filtered by job_type with a limit."""
     for _ in range(5):
-        create_job("collect_main_files", username="z")
+        j = create_job("collect_main_files", username="z")
+        update_job_status(j.id, "completed", job_type="collect_main_files")
     for _ in range(3):
-        create_job("fix_nested_main_files", username="z")
+        j = create_job("fix_nested_main_files", username="z")
+        update_job_status(j.id, "completed", job_type="fix_nested_main_files")
 
     # Filter by type with limit
     collect_jobs = list_jobs(limit=2, job_type="collect_main_files")


### PR DESCRIPTION
Implemented a check to prevent multiple background jobs of the same type from running simultaneously. This is achieved by checking the database for any jobs with 'pending' or 'running' status before starting a new one. A custom `JobAlreadyRunningError` is raised and handled in the routes by displaying a warning message to the user. Added unit tests to verify the behavior and ensured all existing tests pass.

To solve #253 

---
*PR created automatically by Jules for task [8813173570812793016](https://jules.google.com/task/8813173570812793016) started by @MrIbrahem*