### PR TITLE
OWID Chart Slug Redirect Review Workflow

### DIFF
--- a/sql_tables.sql
+++ b/sql_tables.sql
@@ -99,6 +99,18 @@ CREATE TABLE IF NOT EXISTS owid_charts (
     KEY idx_published (is_published)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
 
+CREATE TABLE IF NOT EXISTS owid_slug_redirects (
+    id INT NOT NULL AUTO_INCREMENT,
+    slug VARCHAR(255) NOT NULL,
+    redirect_to VARCHAR(255) NOT NULL,
+    should_be_replaced TINYINT(1) DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY unique_slug_redirect (slug, redirect_to),
+    KEY idx_slug (slug),
+    KEY idx_redirect_to (redirect_to)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4;
+
 CREATE OR REPLACE VIEW owid_charts_templates AS
 SELECT
     c.chart_id,

--- a/src/main_app/app_routes/admin/routes.py
+++ b/src/main_app/app_routes/admin/routes.py
@@ -16,6 +16,7 @@ from ..admin_routes import (
     coordinators_module,
     jobs_module,
     owidcharts_module,
+    slug_redirects_module,
     settings_module,
     templates_module,
 )
@@ -88,6 +89,7 @@ def register_blueprints(bp_admin) -> None:
     bp_admin.register_blueprint(settings_module.bp)
     bp_admin.register_blueprint(jobs_module.bp)
     bp_admin.register_blueprint(owidcharts_module.bp)
+    bp_admin.register_blueprint(slug_redirects_module.bp)
 
 
 register_blueprints(bp_admin)

--- a/src/main_app/app_routes/admin/sidebar.py
+++ b/src/main_app/app_routes/admin/sidebar.py
@@ -97,6 +97,13 @@ def create_side(active_route, path: str | None = None):
                 title="OWID Charts",
                 icon="bi-graph-up",
             ),
+            SidebarItem(
+                id="slug_redirects",
+                admin=1,
+                href=_safe_url_for("admin.slugredirects.dashboard", "/admin/slugredirects/"),
+                title="Slug Redirects",
+                icon="bi-arrow-right-circle",
+            ),
         ],
         "DB jobs": [
             SidebarItem(

--- a/src/main_app/app_routes/admin_routes/__init__.py
+++ b/src/main_app/app_routes/admin_routes/__init__.py
@@ -3,6 +3,7 @@
 from .coordinators import coordinators_module
 from .jobs import jobs_module
 from .owid_charts import owidcharts_module
+from .slug_redirects import slug_redirects_module
 from .settings import settings_module
 from .templates import templates_module
 
@@ -10,6 +11,7 @@ __all__ = [
     "coordinators_module",
     "jobs_module",
     "owidcharts_module",
+    "slug_redirects_module",
     "settings_module",
     "templates_module",
 ]

--- a/src/main_app/app_routes/admin_routes/slug_redirects.py
+++ b/src/main_app/app_routes/admin_routes/slug_redirects.py
@@ -103,7 +103,7 @@ class SlugRedirects:
             else:
                 flash("Slug redirect not found.", "danger")
             return redirect(url_for("admin.slugredirects.dashboard"))
-
+            
         @self.bp.post("/bulk_action")
         @admin_required
         def bulk_action() -> ResponseReturnValue:
@@ -115,17 +115,16 @@ class SlugRedirects:
                 return redirect(url_for("admin.slugredirects.dashboard"))
 
             if action == "mark_replace":
-                for rid in selected_ids:
-                    update_slug_redirect(rid, {"should_be_replaced": True})
+                bulk_update_slug_redirects(selected_ids, {"should_be_replaced": True})
                 flash(f"Marked {len(selected_ids)} redirects as 'replace'.", "success")
             elif action == "mark_no_replace":
-                for rid in selected_ids:
-                    update_slug_redirect(rid, {"should_be_replaced": False})
+                bulk_update_slug_redirects(selected_ids, {"should_be_replaced": False})
                 flash(f"Marked {len(selected_ids)} redirects as 'do not replace'.", "success")
             elif action == "delete":
-                for rid in selected_ids:
-                    delete_slug_redirect(rid)
+                bulk_delete_slug_redirects(selected_ids)
                 flash(f"Deleted {len(selected_ids)} redirects.", "success")
+            else:
+                flash("Invalid action.", "danger")
 
             return redirect(url_for("admin.slugredirects.dashboard"))
 

--- a/src/main_app/app_routes/admin_routes/slug_redirects.py
+++ b/src/main_app/app_routes/admin_routes/slug_redirects.py
@@ -15,6 +15,8 @@ from flask import (
 from flask.typing import ResponseReturnValue
 
 from ...db.services import (
+    bulk_delete_slug_redirects,
+    bulk_update_slug_redirects,
     count_slug_redirects,
     delete_slug_redirect,
     get_slug_redirect_by_id,
@@ -84,8 +86,10 @@ class SlugRedirects:
                 flash("Redirect ID is required.", "danger")
                 return redirect(url_for("admin.slugredirects.dashboard"))
 
-            update_slug_redirect(redirect_id, {"should_be_replaced": should_be_replaced})
-            flash("Slug redirect updated.", "success")
+            if update_slug_redirect(redirect_id, {"should_be_replaced": should_be_replaced}):
+                flash("Slug redirect updated.", "success")
+            else:
+                flash("Slug redirect not found.", "danger")
 
             if from_popup:
                 return render_template("admins/popup_action.html")
@@ -94,8 +98,10 @@ class SlugRedirects:
         @self.bp.post("/<int:redirect_id>/delete")
         @admin_required
         def delete_slug_redirect_data(redirect_id: int) -> ResponseReturnValue:
-            delete_slug_redirect(redirect_id)
-            flash("Slug redirect deleted.", "success")
+            if delete_slug_redirect(redirect_id):
+                flash("Slug redirect deleted.", "success")
+            else:
+                flash("Slug redirect not found.", "danger")
             return redirect(url_for("admin.slugredirects.dashboard"))
 
         @self.bp.post("/bulk_action")

--- a/src/main_app/app_routes/admin_routes/slug_redirects.py
+++ b/src/main_app/app_routes/admin_routes/slug_redirects.py
@@ -1,0 +1,131 @@
+"""Slug Redirects administration routes."""
+
+from __future__ import annotations
+
+import logging
+
+from flask import (
+    Blueprint,
+    flash,
+    redirect,
+    render_template,
+    request,
+    url_for,
+)
+from flask.typing import ResponseReturnValue
+
+from ...db.services import (
+    count_slug_redirects,
+    delete_slug_redirect,
+    get_slug_redirect_by_id,
+    list_slug_redirects,
+    update_slug_redirect,
+)
+from ..admin.admins_required import admin_required
+
+logger = logging.getLogger(__name__)
+
+
+def _edit_slug_redirect(redirect_id: int) -> ResponseReturnValue:
+    """Render the edit slug redirect popup page."""
+    record = get_slug_redirect_by_id(redirect_id)
+    if not record:
+        return render_template(
+            "admins/slug_redirects/edit.html",
+            error="Redirect record not found",
+            record=None,
+        )
+
+    return render_template(
+        "admins/slug_redirects/edit.html",
+        record=record,
+        error=None,
+    )
+
+
+class SlugRedirects:
+
+    def __init__(self):
+        self.bp = Blueprint("slugredirects", __name__, url_prefix="/slugredirects")
+        self._setup_routes()
+
+    def _setup_routes(self):
+        @self.bp.get("/")
+        @admin_required
+        def dashboard():
+            page = request.args.get("page", 1, type=int)
+            per_page = 50
+            offset = (page - 1) * per_page
+
+            records = list_slug_redirects(limit=per_page, offset=offset)
+            total = count_slug_redirects()
+
+            return render_template(
+                "admins/slug_redirects/list.html",
+                records=records,
+                page=page,
+                total=total,
+                per_page=per_page
+            )
+
+        @self.bp.get("/<int:redirect_id>/edit")
+        @admin_required
+        def edit_slug_redirect(redirect_id: int) -> ResponseReturnValue:
+            return _edit_slug_redirect(redirect_id)
+
+        @self.bp.post("/update")
+        @admin_required
+        def update_slug_redirect_data() -> ResponseReturnValue:
+            redirect_id = request.form.get("id", type=int)
+            from_popup = request.form.get("from_popup") == "1"
+            should_be_replaced = request.form.get("should_be_replaced") == "on"
+
+            if not redirect_id:
+                flash("Redirect ID is required.", "danger")
+                return redirect(url_for("admin.slugredirects.dashboard"))
+
+            update_slug_redirect(redirect_id, {"should_be_replaced": should_be_replaced})
+            flash("Slug redirect updated.", "success")
+
+            if from_popup:
+                return render_template("admins/popup_action.html")
+            return redirect(url_for("admin.slugredirects.dashboard"))
+
+        @self.bp.post("/<int:redirect_id>/delete")
+        @admin_required
+        def delete_slug_redirect_data(redirect_id: int) -> ResponseReturnValue:
+            delete_slug_redirect(redirect_id)
+            flash("Slug redirect deleted.", "success")
+            return redirect(url_for("admin.slugredirects.dashboard"))
+
+        @self.bp.post("/bulk_action")
+        @admin_required
+        def bulk_action() -> ResponseReturnValue:
+            action = request.form.get("action")
+            selected_ids = request.form.getlist("selected_ids", type=int)
+
+            if not selected_ids:
+                flash("No items selected.", "warning")
+                return redirect(url_for("admin.slugredirects.dashboard"))
+
+            if action == "mark_replace":
+                for rid in selected_ids:
+                    update_slug_redirect(rid, {"should_be_replaced": True})
+                flash(f"Marked {len(selected_ids)} redirects as 'replace'.", "success")
+            elif action == "mark_no_replace":
+                for rid in selected_ids:
+                    update_slug_redirect(rid, {"should_be_replaced": False})
+                flash(f"Marked {len(selected_ids)} redirects as 'do not replace'.", "success")
+            elif action == "delete":
+                for rid in selected_ids:
+                    delete_slug_redirect(rid)
+                flash(f"Deleted {len(selected_ids)} redirects.", "success")
+
+            return redirect(url_for("admin.slugredirects.dashboard"))
+
+
+slug_redirects_module = SlugRedirects()
+
+__all__ = [
+    "slug_redirects_module",
+]

--- a/src/main_app/app_routes/admin_routes/slug_redirects.py
+++ b/src/main_app/app_routes/admin_routes/slug_redirects.py
@@ -55,7 +55,7 @@ class SlugRedirects:
         @self.bp.get("/")
         @admin_required
         def dashboard():
-            page = request.args.get("page", 1, type=int)
+            page = max(1, request.args.get("page", 1, type=int))
             per_page = 50
             offset = (page - 1) * per_page
 

--- a/src/main_app/db/models/__init__.py
+++ b/src/main_app/db/models/__init__.py
@@ -1,5 +1,6 @@
 from .jobs import JobRecord
 from .owid_charts import OwidChartRecord
+from .owid_slug_redirects import OwidSlugRedirectRecord
 from .settings import SettingRecord
 from .templates import TemplateRecord
 from .users import AdminUserRecord, UserTokenRecord
@@ -13,6 +14,7 @@ __all__ = [
     "AdminUserRecord",
     "JobRecord",
     "OwidChartRecord",
+    "OwidSlugRedirectRecord",
     "SettingRecord",
     "TemplateRecord",
     "TemplateNeedUpdateRecord",

--- a/src/main_app/db/models/owid_slug_redirects.py
+++ b/src/main_app/db/models/owid_slug_redirects.py
@@ -28,7 +28,7 @@ class OwidSlugRedirectRecord(db.Model):
     __tablename__ = "owid_slug_redirects"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    slug = Column(String(255), nullable=False)
+    slug = Column(String(255), nullable=False, unique=True)
     redirect_to = Column(String(255), nullable=False)
     should_be_replaced = Column(Boolean, server_default="0", default=False)
     created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())

--- a/src/main_app/db/models/owid_slug_redirects.py
+++ b/src/main_app/db/models/owid_slug_redirects.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, func
+
+from ...extensions import db
+
+logger = logging.getLogger(__name__)
+
+
+class OwidSlugRedirectRecord(db.Model):
+    """
+    CREATE TABLE `owid_slug_redirects` (
+        `id` int(11) NOT NULL AUTO_INCREMENT,
+        `slug` varchar(255) NOT NULL,
+        `redirect_to` varchar(255) NOT NULL,
+        `should_be_replaced` tinyint(1) DEFAULT 0,
+        `created_at` timestamp NOT NULL DEFAULT current_timestamp(),
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `unique_slug_redirect` (`slug`, `redirect_to`),
+        KEY `idx_slug` (`slug`),
+        KEY `idx_redirect_to` (`redirect_to`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+    """
+
+    __tablename__ = "owid_slug_redirects"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    slug = Column(String(255), nullable=False)
+    redirect_to = Column(String(255), nullable=False)
+    should_be_replaced = Column(Boolean, server_default="0", default=False)
+    created_at = Column(DateTime, nullable=False, server_default=func.current_timestamp())
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {}
+        for column in self.__table__.columns:
+            value = getattr(self, column.name)
+            if hasattr(value, "isoformat"):
+                value = value.isoformat()
+            data[column.name] = value
+        return data
+
+
+__all__ = [
+    "OwidSlugRedirectRecord",
+]

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -93,6 +93,8 @@ __all__ = [
     "update_slug_redirect",
     "delete_slug_redirect",
     "count_slug_redirects",
+    "bulk_update_slug_redirects",
+    "bulk_delete_slug_redirects",
     # settings_service
     "get_all_settings_ready",
     "get_all_settings_raw",

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -24,6 +24,14 @@ from .owid_charts_service import (
     list_published_charts,
     update_chart_data,
 )
+from .owid_slugs_redirects_service import (
+    add_new_slug_redirect,
+    count_slug_redirects,
+    delete_slug_redirect,
+    get_slug_redirect_by_id,
+    list_slug_redirects,
+    update_slug_redirect,
+)
 from .settings_service import (
     create_setting,
     delete_setting,
@@ -78,6 +86,13 @@ __all__ = [
     "delete_chart",
     "list_charts",
     "list_published_charts",
+    # owid_slugs_redirects_service
+    "add_new_slug_redirect",
+    "list_slug_redirects",
+    "get_slug_redirect_by_id",
+    "update_slug_redirect",
+    "delete_slug_redirect",
+    "count_slug_redirects",
     # settings_service
     "get_all_settings_ready",
     "get_all_settings_raw",

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -26,6 +26,8 @@ from .owid_charts_service import (
 )
 from .owid_slugs_redirects_service import (
     add_new_slug_redirect,
+    bulk_delete_slug_redirects,
+    bulk_update_slug_redirects,
     count_slug_redirects,
     delete_slug_redirect,
     get_slug_redirect_by_id,

--- a/src/main_app/db/services/owid_slugs_redirects_service.py
+++ b/src/main_app/db/services/owid_slugs_redirects_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy import desc
+
+from ...extensions import db
+from ..models.owid_slug_redirects import OwidSlugRedirectRecord
+from .utils import db_guard_rollback
+
+logger = logging.getLogger(__name__)
+
+
+@db_guard_rollback
+def add_new_slug_redirect(slug: str, redirect_to: str) -> None:
+    """
+    Add a new slug redirect record if it doesn't already exist.
+    """
+    existing = (
+        db.session.query(OwidSlugRedirectRecord)
+        .filter(OwidSlugRedirectRecord.slug == slug, OwidSlugRedirectRecord.redirect_to == redirect_to)
+        .first()
+    )
+
+    if not existing:
+        new_record = OwidSlugRedirectRecord(slug=slug, redirect_to=redirect_to)
+        db.session.add(new_record)
+        db.session.commit()
+        logger.info(f"Added new slug redirect: {slug} -> {redirect_to}")
+
+
+def list_slug_redirects(limit: int | None = None, offset: int | None = None) -> list[OwidSlugRedirectRecord]:
+    """
+    List slug redirects ordered by created_at DESC.
+    """
+    query = db.session.query(OwidSlugRedirectRecord).order_by(desc(OwidSlugRedirectRecord.created_at))
+    if limit is not None:
+        query = query.limit(limit)
+    if offset is not None:
+        query = query.offset(offset)
+    return query.all()
+
+
+def get_slug_redirect_by_id(redirect_id: int) -> OwidSlugRedirectRecord | None:
+    """
+    Fetch a slug redirect by ID.
+    """
+    return db.session.query(OwidSlugRedirectRecord).filter(OwidSlugRedirectRecord.id == redirect_id).first()
+
+
+@db_guard_rollback
+def update_slug_redirect(redirect_id: int, data: dict[str, Any]) -> OwidSlugRedirectRecord | None:
+    """
+    Update a slug redirect record.
+    """
+    record = get_slug_redirect_by_id(redirect_id)
+    if record:
+        for key, value in data.items():
+            if hasattr(OwidSlugRedirectRecord, key):
+                setattr(record, key, value)
+        db.session.commit()
+        db.session.refresh(record)
+    return record
+
+
+@db_guard_rollback
+def delete_slug_redirect(redirect_id: int) -> bool:
+    """
+    Delete a slug redirect record.
+    """
+    record = get_slug_redirect_by_id(redirect_id)
+    if record:
+        db.session.delete(record)
+        db.session.commit()
+        return True
+    return False
+
+
+def count_slug_redirects() -> int:
+    """
+    Count total slug redirect records.
+    """
+    return db.session.query(OwidSlugRedirectRecord).count()
+
+
+__all__ = [
+    "add_new_slug_redirect",
+    "list_slug_redirects",
+    "get_slug_redirect_by_id",
+    "update_slug_redirect",
+    "delete_slug_redirect",
+    "count_slug_redirects",
+]

--- a/src/main_app/db/services/owid_slugs_redirects_service.py
+++ b/src/main_app/db/services/owid_slugs_redirects_service.py
@@ -86,6 +86,32 @@ def count_slug_redirects() -> int:
     return db.session.query(OwidSlugRedirectRecord).count()
 
 
+@db_guard_rollback
+def bulk_update_slug_redirects(redirect_ids: list[int], data: dict[str, Any]) -> None:
+    """
+    Bulk update slug redirect records.
+    """
+    allowed_keys = {"should_be_replaced"}
+    update_data = {k: v for k, v in data.items() if k in allowed_keys}
+    if update_data and redirect_ids:
+        db.session.query(OwidSlugRedirectRecord).filter(OwidSlugRedirectRecord.id.in_(redirect_ids)).update(
+            update_data, synchronize_session=False
+        )
+        db.session.commit()
+
+
+@db_guard_rollback
+def bulk_delete_slug_redirects(redirect_ids: list[int]) -> None:
+    """
+    Bulk delete slug redirect records.
+    """
+    if redirect_ids:
+        db.session.query(OwidSlugRedirectRecord).filter(OwidSlugRedirectRecord.id.in_(redirect_ids)).delete(
+            synchronize_session=False
+        )
+        db.session.commit()
+
+
 __all__ = [
     "add_new_slug_redirect",
     "list_slug_redirects",
@@ -93,4 +119,6 @@ __all__ = [
     "update_slug_redirect",
     "delete_slug_redirect",
     "count_slug_redirects",
+    "bulk_update_slug_redirects",
+    "bulk_delete_slug_redirects",
 ]

--- a/src/main_app/db/services/owid_slugs_redirects_service.py
+++ b/src/main_app/db/services/owid_slugs_redirects_service.py
@@ -50,14 +50,16 @@ def get_slug_redirect_by_id(redirect_id: int) -> OwidSlugRedirectRecord | None:
 
 
 @db_guard_rollback
+@db_guard_rollback
 def update_slug_redirect(redirect_id: int, data: dict[str, Any]) -> OwidSlugRedirectRecord | None:
     """
     Update a slug redirect record.
     """
     record = get_slug_redirect_by_id(redirect_id)
     if record:
+        allowed_keys = {"slug", "redirect_to", "should_be_replaced"}
         for key, value in data.items():
-            if hasattr(OwidSlugRedirectRecord, key):
+            if key in allowed_keys:
                 setattr(record, key, value)
         db.session.commit()
         db.session.refresh(record)

--- a/src/main_app/jobs_workers/collect_templates_data/worker.py
+++ b/src/main_app/jobs_workers/collect_templates_data/worker.py
@@ -19,6 +19,7 @@ from ...api_services.clients.owid_client import fetch_grapher_metadata
 from ...api_services.pages_api import get_page_text
 from ...db.models import TemplateRecord
 from ...db.services import (
+    add_new_slug_redirect,
     add_template_data,
     get_chart_by_slug,
     list_templates,
@@ -391,7 +392,7 @@ class CollectMainFilesWorker(BaseJobWorker):
                 if original_chart_url and "/grapher/" in original_chart_url:
                     original_slug = original_chart_url.split("/grapher/", maxsplit=1)[1].split("?")[0]
                     if original_slug != _slug_to_check:
-                        _slug = original_slug
+                        add_new_slug_redirect(slug=_slug_to_check, redirect_to=original_slug)
 
         if not _slug and "/grapher/" not in template_source:
             raise Exception("source url does not have /grapher/")

--- a/src/main_app/jobs_workers/update_owid_charts/worker.py
+++ b/src/main_app/jobs_workers/update_owid_charts/worker.py
@@ -25,7 +25,7 @@ from typing import Any, Dict
 
 from ...api_services.clients.owid_client import fetch_grapher_metadata
 from ...db.models.owid_charts import OwidChartRecord
-from ...db.services import owid_charts_service
+from ...db.services import add_new_slug_redirect, owid_charts_service
 from ..base_worker import BaseJobWorker
 
 logger = logging.getLogger(__name__)
@@ -184,8 +184,7 @@ class UpdateOwidChartsWorker(BaseJobWorker):
         if original_chart_url and "/grapher/" in original_chart_url:
             original_slug = original_chart_url.split("/grapher/", maxsplit=1)[1].split("?")[0]
             if original_slug != chart.slug:
-                data["slug"] = original_slug
-                # TODO: find any template use slug and replace it by new slug, or create database table for slug redirects
+                add_new_slug_redirect(slug=chart.slug, redirect_to=original_slug)
 
         # 2. Find a timespan
         columns = metadata.get("columns", {})

--- a/src/templates/admins/slug_redirects/edit.html
+++ b/src/templates/admins/slug_redirects/edit.html
@@ -1,0 +1,37 @@
+<div class="modal-header">
+    <h5 class="modal-title">Edit Slug Redirect</h5>
+    <button type="button" class="btn-close" onclick="pup_close()"></button>
+</div>
+<div class="modal-body">
+    {% if error %}
+    <div class="alert alert-danger">{{ error }}</div>
+    {% endif %}
+
+    {% if record %}
+    <form action="{{ url_for('admin.slugredirects.update_slug_redirect_data') }}" method="POST">
+        <input type="hidden" name="id" value="{{ record.id }}">
+        <input type="hidden" name="from_popup" value="1">
+
+        <div class="mb-3">
+            <label class="form-label">Original Slug</label>
+            <input type="text" class="form-control" value="{{ record.slug }}" readonly disabled>
+        </div>
+
+        <div class="mb-3">
+            <label class="form-label">Redirect To</label>
+            <input type="text" class="form-control" value="{{ record.redirect_to }}" readonly disabled>
+        </div>
+
+        <div class="mb-3 form-check">
+            <input type="checkbox" class="form-check-input" id="should_be_replaced" name="should_be_replaced" {% if record.should_be_replaced %}checked{% endif %}>
+            <label class="form-check-label" for="should_be_replaced">Should be replaced</label>
+            <div class="form-text">If checked, the original slug may be replaced by the redirect target in future operations.</div>
+        </div>
+
+        <div class="text-end">
+            <button type="button" class="btn btn-secondary" onclick="pup_close()">Cancel</button>
+            <button type="submit" class="btn btn-primary">Save Changes</button>
+        </div>
+    </form>
+    {% endif %}
+</div>

--- a/src/templates/admins/slug_redirects/list.html
+++ b/src/templates/admins/slug_redirects/list.html
@@ -1,0 +1,123 @@
+{% extends "admins/base1.html" %}
+{% block title %}Slug Redirects · Copy SVG Translation{% endblock %}
+{% block contents %}
+
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="headline mb-0">Slug Redirects</h3>
+    </div>
+    <div class="card-body">
+        <form id="bulkActionForm" action="{{ url_for('admin.slugredirects.bulk_action') }}" method="POST">
+            <div class="d-flex justify-content-between mb-3">
+                <div class="input-group" style="width: auto;">
+                    <select name="action" class="form-select form-select-sm">
+                        <option value="">Bulk Actions</option>
+                        <option value="mark_replace">Mark as Replace</option>
+                        <option value="mark_no_replace">Mark as Do Not Replace</option>
+                        <option value="delete">Delete</option>
+                    </select>
+                    <button type="submit" class="btn btn-outline-secondary btn-sm">Apply</button>
+                </div>
+                <div>
+                    <span class="text-muted">Total: {{ total }}</span>
+                </div>
+            </div>
+
+            <div class="table-responsive shadow-sm">
+                <table class="table table-hover align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th scope="col" style="width: 40px;">
+                                <input type="checkbox" id="selectAll">
+                            </th>
+                            <th scope="col">Original Slug</th>
+                            <th scope="col">Redirect To</th>
+                            <th scope="col" class="text-center">Should Replace</th>
+                            <th scope="col">Created At</th>
+                            <th scope="col" class="text-center">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for record in records %}
+                        <tr>
+                            <td>
+                                <input type="checkbox" name="selected_ids" value="{{ record.id }}" class="select-item">
+                            </td>
+                            <td>
+                                <a href="https://ourworldindata.org/grapher/{{ record.slug }}" target="_blank"><code>{{ record.slug }}</code></a>
+                            </td>
+                            <td>
+                                <a href="https://ourworldindata.org/grapher/{{ record.redirect_to }}" target="_blank"><code>{{ record.redirect_to }}</code></a>
+                            </td>
+                            <td class="text-center">
+                                {% if record.should_be_replaced %}
+                                <span class="badge bg-success">Yes</span>
+                                {% else %}
+                                <span class="badge bg-secondary">No</span>
+                                {% endif %}
+                            </td>
+                            <td>{{ record.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</td>
+                            <td class="text-center">
+                                <button type="button" class="btn btn-outline-primary btn-sm"
+                                    pup-target="{{ url_for('admin.slugredirects.edit_slug_redirect', redirect_id=record.id) }}"
+                                    onclick="pup_window_new(this, 600, 400)">
+                                    <i class="bi bi-pencil"></i> Edit
+                                </button>
+                                <form action="{{ url_for('admin.slugredirects.delete_slug_redirect_data', redirect_id=record.id) }}" method="POST" class="d-inline" onsubmit="return confirm('Are you sure?')">
+                                    <button type="submit" class="btn btn-outline-danger btn-sm">
+                                        <i class="bi bi-trash"></i>
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                        {% else %}
+                        <tr>
+                            <td colspan="6" class="text-center text-muted">No redirect records found.</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </form>
+
+        {% if total > per_page %}
+        <nav aria-label="Page navigation" class="mt-4">
+            <ul class="pagination justify-content-center">
+                {% set total_pages = (total // per_page) + (1 if total % per_page > 0 else 0) %}
+                <li class="page-item {% if page <= 1 %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('admin.slugredirects.dashboard', page=page-1) }}">Previous</a>
+                </li>
+                {% for p in range(1, total_pages + 1) %}
+                <li class="page-item {% if p == page %}active{% endif %}">
+                    <a class="page-link" href="{{ url_for('admin.slugredirects.dashboard', page=p) }}">{{ p }}</a>
+                </li>
+                {% endfor %}
+                <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
+                    <a class="page-link" href="{{ url_for('admin.slugredirects.dashboard', page=page+1) }}">Next</a>
+                </li>
+            </ul>
+        </nav>
+        {% endif %}
+    </div>
+</div>
+
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    $(document).ready(function() {
+        $('#selectAll').on('click', function() {
+            $('.select-item').prop('checked', this.checked);
+        });
+
+        $('.select-item').on('click', function() {
+            if (!this.checked) {
+                $('#selectAll').prop('checked', false);
+            }
+            if ($('.select-item:checked').length === $('.select-item').length) {
+                $('#selectAll').prop('checked', true);
+            }
+        });
+    });
+</script>
+{% endblock %}

--- a/tests/unit/services/test_owid_slugs_redirects_service.py
+++ b/tests/unit/services/test_owid_slugs_redirects_service.py
@@ -37,6 +37,17 @@ def test_add_new_slug_redirect_existing(mock_db_session):
     add_new_slug_redirect("old-slug", "new-slug")
 
     assert not mock_db_session.add.called
+    assert not mock_db_session.commit.called
+
+
+def test_add_new_slug_redirect_update_target(mock_db_session):
+    existing_record = OwidSlugRedirectRecord(slug="old-slug", redirect_to="old-target")
+    mock_db_session.query().filter().first.return_value = existing_record
+
+    add_new_slug_redirect("old-slug", "new-target")
+
+    assert existing_record.redirect_to == "new-target"
+    assert mock_db_session.commit.called
 
 
 def test_list_slug_redirects(mock_db_session):

--- a/tests/unit/services/test_owid_slugs_redirects_service.py
+++ b/tests/unit/services/test_owid_slugs_redirects_service.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.main_app.db.models.owid_slug_redirects import OwidSlugRedirectRecord
+from src.main_app.db.services.owid_slugs_redirects_service import (
+    add_new_slug_redirect,
+    count_slug_redirects,
+    delete_slug_redirect,
+    get_slug_redirect_by_id,
+    list_slug_redirects,
+    update_slug_redirect,
+)
+
+
+@pytest.fixture
+def mock_db_session(monkeypatch: pytest.MonkeyPatch):
+    mock_session = MagicMock()
+    monkeypatch.setattr("src.main_app.extensions.db.session", mock_session)
+    return mock_session
+
+
+def test_add_new_slug_redirect_new(mock_db_session):
+    mock_db_session.query().filter().first.return_value = None
+
+    add_new_slug_redirect("old-slug", "new-slug")
+
+    assert mock_db_session.add.called
+    assert mock_db_session.commit.called
+
+
+def test_add_new_slug_redirect_existing(mock_db_session):
+    mock_db_session.query().filter().first.return_value = OwidSlugRedirectRecord(slug="old-slug", redirect_to="new-slug")
+
+    add_new_slug_redirect("old-slug", "new-slug")
+
+    assert not mock_db_session.add.called
+
+
+def test_list_slug_redirects(mock_db_session):
+    mock_db_session.query().order_by().limit().offset().all.return_value = []
+
+    results = list_slug_redirects(limit=10, offset=0)
+
+    assert results == []
+
+
+def test_get_slug_redirect_by_id(mock_db_session):
+    record = OwidSlugRedirectRecord(id=1)
+    mock_db_session.query().filter().first.return_value = record
+
+    result = get_slug_redirect_by_id(1)
+
+    assert result == record
+
+
+def test_update_slug_redirect(mock_db_session):
+    record = OwidSlugRedirectRecord(id=1, should_be_replaced=False)
+    mock_db_session.query().filter().first.return_value = record
+
+    update_slug_redirect(1, {"should_be_replaced": True})
+
+    assert record.should_be_replaced is True
+    assert mock_db_session.commit.called
+
+
+def test_delete_slug_redirect(mock_db_session):
+    record = OwidSlugRedirectRecord(id=1)
+    mock_db_session.query().filter().first.return_value = record
+
+    result = delete_slug_redirect(1)
+
+    assert result is True
+    assert mock_db_session.delete.called
+    assert mock_db_session.commit.called
+
+
+def test_count_slug_redirects(mock_db_session):
+    mock_db_session.query().count.return_value = 5
+
+    assert count_slug_redirects() == 5


### PR DESCRIPTION
This PR introduces a database-backed workflow for reviewing OWID chart slug redirects. 

Instead of automatically updating slugs when a redirect is detected in the `originalChartUrl` metadata, the application now logs these redirects to a new `owid_slug_redirects` table. Administrators can then review these redirects through a new dashboard in the admin panel, where they can manually decide whether to mark them for replacement or delete them.

Key changes:
- New SQLAlchemy model `OwidSlugRedirectRecord`.
- Updated `sql_tables.sql` with the new table schema.
- New service layer `owid_slugs_redirects_service.py` for managing redirect records.
- Modified background workers to use the review workflow.
- New admin routes and templates for managing redirects.
- Added unit tests for the redirect service.

---
*PR created automatically by Jules for task [15352039698415815394](https://jules.google.com/task/15352039698415815394) started by @MrIbrahem*