### PR TITLE
Fix test errors and synchronize with implementation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def stop_nets():
 
 
 @pytest.fixture
-def app() -> Generator[Flask, Any]:
+def app() -> Generator[Flask, Any, None]:
     """Create and configure a test Flask application.
 
     Yields:

--- a/tests/unit/api_services/test_mwclient_page.py
+++ b/tests/unit/api_services/test_mwclient_page.py
@@ -43,13 +43,13 @@ class TestLoadPage:
     def test_invalid_page_title(self, mw_client, mock_site):
         mock_site.pages.__getitem__.side_effect = mwclient.errors.InvalidPageTitle("bad title")
         result = mw_client.load_page()
-        assert result is False
+        assert result is None
         assert mw_client.load_page_error == "invalidpagetitle"
 
     def test_generic_exception(self, mw_client, mock_site):
         mock_site.pages.__getitem__.side_effect = Exception("connection error")
         result = mw_client.load_page()
-        assert result is False
+        assert result is None
         assert mw_client.load_page_error == "connection error"
 
 
@@ -192,15 +192,16 @@ class TestEditWithRetry:
     def test_succeeds_on_first_retry(self, mw_client, mock_exists_page):
         mock_exists_page.edit.side_effect = [None]  # succeeds immediately
         with patch("src.main_app.api_services.mwclient_page.time.sleep"):
-            result = mw_client._edit_with_retry(mock_exists_page, "text", "summary")
+            result = mw_client._with_retry(mw_client._edit_page, mock_exists_page, "text", "summary")
         assert result == {"success": True}
 
     def test_returns_ratelimited_after_all_retries(self, mw_client, mock_exists_page):
         mock_exists_page.edit.side_effect = make_api_error("ratelimited")
         with patch("src.main_app.api_services.mwclient_page.time.sleep"):
-            result = mw_client._edit_with_retry(mock_exists_page, "text", "summary", nocreate=1)
+            result = mw_client._with_retry(mw_client._edit_page, mock_exists_page, "text", "summary", nocreate=1)
         assert result == {"success": False, "error": "ratelimited"}
-        assert mock_exists_page.edit.call_count == len(_RETRY_DELAYS)
+        # 1 initial + len(_RETRY_DELAYS)
+        assert mock_exists_page.edit.call_count == 1 + len(_RETRY_DELAYS)
 
     def test_stops_early_on_non_ratelimited_error(self, mw_client, mock_exists_page):
         mock_exists_page.edit.side_effect = [
@@ -208,7 +209,7 @@ class TestEditWithRetry:
             mwclient.errors.AssertUserFailedError(),
         ]
         with patch("src.main_app.api_services.mwclient_page.time.sleep"):
-            result = mw_client._edit_with_retry(mock_exists_page, "text", "summary")
+            result = mw_client._with_retry(mw_client._edit_page, mock_exists_page, "text", "summary")
         assert result == {"success": False, "error": "assertuserfailed"}
         assert mock_exists_page.edit.call_count == 2
 

--- a/tests/unit/api_services/test_pages_api.py
+++ b/tests/unit/api_services/test_pages_api.py
@@ -59,7 +59,7 @@ class TestIsPageExists:
             result = is_page_exists("File:Existing.svg", mock_site)
 
         assert result is True
-        assert "Title File:Existing.svg exists" in caplog.text
+        assert "Page 'File:Existing.svg' exists" in caplog.text
 
     def test_page_not_exists_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test that is_page_exists logs a warning when page not exists."""
@@ -73,7 +73,7 @@ class TestIsPageExists:
             result = is_page_exists("File:Not-existing.svg", mock_site)
 
         assert result is False
-        assert "Title File:Not-existing.svg does not exist" in caplog.text
+        assert "Page 'File:Not-existing.svg' does not exist" in caplog.text
 
 
 class TestCreatePage:
@@ -83,6 +83,7 @@ class TestCreatePage:
         """Test successful page creation."""
         mock_site = MagicMock(spec=mwclient.Site)
         mock_page = MagicMock()
+        mock_page.exists = False
         mock_site.pages = MagicMock()
         mock_site.pages.__getitem__ = MagicMock(return_value=mock_page)
 
@@ -95,12 +96,13 @@ class TestCreatePage:
 
         assert result == {"success": True}
         mock_site.pages.__getitem__.assert_called_once_with("File:Test.svg")
-        mock_page.edit.assert_called_once_with("{{Information}}", summary="Test summary", nocreate=0)
+        mock_page.edit.assert_called_once_with("{{Information}}", summary="Test summary", onlycreate=True)
 
     def test_create_page_without_summary(self) -> None:
         """Test page creation with default empty summary."""
         mock_site = MagicMock(spec=mwclient.Site)
         mock_page = MagicMock()
+        mock_page.exists = False
         mock_site.pages = MagicMock()
         mock_site.pages.__getitem__ = MagicMock(return_value=mock_page)
 
@@ -111,7 +113,7 @@ class TestCreatePage:
         )
 
         assert result == {"success": True}
-        mock_page.edit.assert_called_once_with("{{Information}}", summary="", nocreate=0)
+        mock_page.edit.assert_called_once_with("{{Information}}", summary="", onlycreate=True)
 
     def test_create_page_missing_page_name(self) -> None:
         """Test create_page returns error when page_name is missing."""
@@ -168,12 +170,13 @@ class TestCreatePage:
 
         assert result["success"] is False
         assert "Page load failed" in result["error"]
-        assert "Failed to load page File:Test.svg" in caplog.text
+        assert "Failed to load page 'File:Test.svg'" in caplog.text
 
     def test_create_page_edit_exception(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test create_page handles exception when edit fails."""
         mock_site = MagicMock(spec=mwclient.Site)
         mock_page = MagicMock()
+        mock_page.exists = False
         mock_site.pages = MagicMock()
         mock_site.pages.__getitem__ = MagicMock(return_value=mock_page)
         mock_page.edit = MagicMock(side_effect=Exception("Edit failed"))
@@ -188,7 +191,7 @@ class TestCreatePage:
 
         assert result["success"] is False
         assert "Edit failed" in result["error"]
-        assert "Failed to edit page File:Test.svg" in caplog.text
+        assert "Failed to edit page 'File:Test.svg'" in caplog.text
 
 
 class TestUpdateFileText:


### PR DESCRIPTION
This PR fixes several test errors that were preventing the test suite from passing.

Changes:
1.  **Type Hint Fix:** In `tests/conftest.py`, the `app` fixture's type hint was updated from `Generator[Flask, Any]` to `Generator[Flask, Any, None]`. Python 3.12's `typing.Generator` requires three arguments, and the missing one was causing a `TypeError` during test collection.
2.  **MWClientPage Test Updates:**
    *   Updated `test_invalid_page_title` and `test_generic_exception` in `tests/unit/api_services/test_mwclient_page.py` to assert that `load_page()` returns `None` on failure, matching the actual implementation.
    *   Renamed calls from the non-existent `_edit_with_retry` to the refactored `_with_retry` method in `TestEditWithRetry`.
3.  **Pages API Test Updates:**
    *   Aligned log message assertions in `tests/unit/api_services/test_pages_api.py` with the actual logging format (added single quotes around page titles).
    *   Updated `TestCreatePage` to correctly mock `page.exists = False` for successful creation and use `onlycreate=True` instead of `nocreate=0` in `edit` call assertions.

After these changes, all 1333 tests in the suite pass successfully.

---
*PR created automatically by Jules for task [11053391357065203687](https://jules.google.com/task/11053391357065203687) started by @MrIbrahem*