### PR TITLE
Update both template and page in Crop Newest World Files Job

### DIFF
--- a/src/main_app/jobs_workers/admin_jobs_workers/crop_main_files/worker.py
+++ b/src/main_app/jobs_workers/admin_jobs_workers/crop_main_files/worker.py
@@ -311,11 +311,16 @@ class CropMainFilesWorker(BaseJobWorker):
         )
 
         # Step 6 - Update corresponding content page
-        updated3 = self._step_update_page_reference(
-            file_info,
-            file_info.template_title.removeprefix("Template:"),
-            "update_page",
-        )
+        template_title = file_info.template_title
+        if template_title.lower().startswith("template:"):
+            updated3 = self._step_update_page_reference(
+                file_info,
+                template_title[9:],
+                "update_page",
+            )
+        else:
+            self._skip_step(file_info, "update_page", "Skipped - title does not start with Template:")
+            updated3 = False
 
         return updated or updated2 or updated3
 
@@ -458,7 +463,7 @@ class CropMainFilesWorker(BaseJobWorker):
         if not page.exists():
             logger.warning(f"Job {self.job_id}: Page does not exist: {page_title}")
             file_info.steps[step_name] = {
-                "result": False,
+                "result": None,
                 "msg": f"Page does not exist: {page_title}",
             }
             return False

--- a/src/main_app/jobs_workers/admin_jobs_workers/crop_main_files/worker.py
+++ b/src/main_app/jobs_workers/admin_jobs_workers/crop_main_files/worker.py
@@ -56,6 +56,7 @@ class TemplateProcessingInfo:
             "upload_cropped": {"result": None, "msg": ""},
             "update_original": {"result": None, "msg": ""},
             "update_template": {"result": None, "msg": ""},
+            "update_page": {"result": None, "msg": ""},
         }
     )
 
@@ -84,6 +85,7 @@ class CropMainFilesWorker(BaseJobWorker):
         3. Upload    - upload the cropped version under a new filename
         4. Update original  - add a link to the cropped file in the original file's wikitext
         5. Update template  - point the template page at the cropped file
+        6. Update page      - point the content page at the cropped file
     """
 
     def __init__(
@@ -302,9 +304,20 @@ class CropMainFilesWorker(BaseJobWorker):
         updated = self._step_update_original(file_info)
 
         # Step 5 - Update template page reference
-        updated2 = self._step_update_template(file_info)
+        updated2 = self._step_update_page_reference(
+            file_info,
+            file_info.template_title,
+            "update_template",
+        )
 
-        return updated or updated2
+        # Step 6 - Update corresponding content page
+        updated3 = self._step_update_page_reference(
+            file_info,
+            file_info.template_title.removeprefix("Template:"),
+            "update_page",
+        )
+
+        return updated or updated2 or updated3
 
     # ------------------------------------------------------------------
     # Individual pipeline steps
@@ -391,6 +404,7 @@ class CropMainFilesWorker(BaseJobWorker):
 
         self._skip_step(file_info, "update_original", "Skipped - upload failed")
         self._skip_step(file_info, "update_template", "Skipped - upload was not successful")
+        self._skip_step(file_info, "update_page", "Skipped - upload was not successful")
 
         self._fail(file_info, "upload_cropped", error)
         file_info.cropped_filename = None
@@ -431,38 +445,68 @@ class CropMainFilesWorker(BaseJobWorker):
         file_info.steps["update_original"] = {"result": False, "msg": error}
         return False
 
-    def _step_update_template(self, file_info: TemplateProcessingInfo) -> bool:
-        """Update the template page to reference the cropped file."""
-        template_title = file_info.template_title
-        template_page = MwClientPage(template_title, self.site)
-        template_text = template_page.get_text()
+    def _step_update_page_reference(
+        self,
+        file_info: TemplateProcessingInfo,
+        page_title: str,
+        step_name: str,
+    ) -> bool:
+        """Update a page to reference the cropped file."""
+
+        page = MwClientPage(page_title, self.site)
+
+        if not page.exists():
+            logger.warning(f"Job {self.job_id}: Page does not exist: {page_title}")
+            file_info.steps[step_name] = {
+                "result": False,
+                "msg": f"Page does not exist: {page_title}",
+            }
+            return False
+
+        page_text = page.get_text()
+
+        if not page_text:
+            logger.warning(f"Job {self.job_id}: Empty page text for {page_title}")
+            file_info.steps[step_name] = {
+                "result": False,
+                "msg": f"Empty page text: {page_title}",
+            }
+            return False
 
         updated_text = update_template_page_file_reference(
             file_info.original_file,
             file_info.cropped_filename,
-            template_text,
+            page_text,
         )
 
-        if template_text == updated_text:
-            logger.info(f"Job {self.job_id}: No update needed for template page {template_title}")
-            file_info.steps["update_template"] = {"result": None, "msg": "No update needed"}
+        if page_text == updated_text:
+            logger.info(f"Job {self.job_id}: No update needed for page {page_title}")
+            file_info.steps[step_name] = {
+                "result": None,
+                "msg": "No update needed",
+            }
             return False
 
         summary = f"Update file reference to [[File:{file_info.cropped_filename.removeprefix('File:')}]]"
-        update_result = template_page.edit(updated_text, summary)
 
-        if update_result["success"]:
-            file_info.steps["update_template"] = {
+        update_result = page.edit(updated_text, summary)
+
+        if update_result.get("success"):
+            file_info.steps[step_name] = {
                 "result": True,
-                "msg": f"Updated template {template_title}",
+                "msg": f"Updated page {page_title}",
                 "newrevid": update_result.get("newrevid", 0),
             }
             return True
 
         error = update_result.get("error", "Unknown error")
-        logger.warning(f"Job {self.job_id}: Failed to update template page {template_title} (reason: {error})")
-        # self._fail(file_info, "update_template", f"Failed to update template {template_title}")
-        file_info.steps["update_template"] = {"result": False, "msg": f"Failed to update template {template_title}"}
+
+        logger.warning(f"Job {self.job_id}: Failed to update page {page_title} (reason: {error})")
+
+        file_info.steps[step_name] = {
+            "result": False,
+            "msg": f"Failed to update page {page_title}: {error}",
+        }
 
         return False
 
@@ -487,7 +531,7 @@ class CropMainFilesWorker(BaseJobWorker):
         file_info.steps[step] = {"result": None, "msg": reason}
 
     def _skip_upload_steps(self, file_info: TemplateProcessingInfo) -> None:
-        for step in ("upload_cropped", "update_original", "update_template"):
+        for step in ("upload_cropped", "update_original", "update_template", "update_page"):
             self._skip_step(file_info, step, "Skipped - upload disabled")
         file_info.status = "skipped"
         self.result["summary"]["skipped"] += 1

--- a/src/templates/jobs_templates/admin/crop_main_files/details.html
+++ b/src/templates/jobs_templates/admin/crop_main_files/details.html
@@ -66,6 +66,7 @@
                             Update File
                         </th>
                         <th>Update Template</th>
+                        <th>Update Page</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -103,7 +104,8 @@
                             'crop',
                             'upload_cropped',
                             'update_original',
-                            'update_template'
+                            'update_template',
+                            'update_page'
                         ] %}
                         {% for step_key in step_keys %}
                         <td>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def stop_nets(request):
 
 
 @pytest.fixture
-def app() -> Generator[Flask, Any]:
+def app() -> Generator[Flask, Any, None]:
     """Create and configure a test Flask application.
 
     Yields:

--- a/tests/unit/jobs_workers/admin_jobs_workers/crop_main_files/test_crop_main_files_worker_run.py
+++ b/tests/unit/jobs_workers/admin_jobs_workers/crop_main_files/test_crop_main_files_worker_run.py
@@ -159,6 +159,7 @@ class TestFileProcessingInfo:
         assert "download" in info.steps
         assert "crop" in info.steps
         assert "upload_cropped" in info.steps
+        assert "update_page" in info.steps
 
     def test_to_dict(self):
         """Test to_dict serialization."""
@@ -579,10 +580,11 @@ class TestCropMainFilesProcessorSteps:
         assert file_info.steps["update_original"]["result"] is False
         assert "Edit conflict" in file_info.steps["update_original"]["msg"]
 
-    def test_step_update_template_no_change(self, mock_services):
-        """Test _step_update_template when no update is needed."""
-        mock_services["MwClientPage"].return_value.get_text.return_value = "Template text"
-        mock_services["update_template_page_file_reference"].return_value = "Template text"  # No change
+    def test_step_update_page_reference_no_change(self, mock_services):
+        """Test _step_update_page_reference when no update is needed."""
+        mock_services["MwClientPage"].return_value.get_text.return_value = "Some text"
+        mock_services["MwClientPage"].return_value.exists.return_value = True
+        mock_services["update_template_page_file_reference"].return_value = "Some text"  # No change
 
         processor = CropMainFilesWorker(
             job_id=1,
@@ -597,16 +599,17 @@ class TestCropMainFilesProcessorSteps:
             cropped_filename="File:test (cropped).svg",
         )
 
-        processor._step_update_template(file_info)
+        processor._step_update_page_reference(file_info, "Template:Test", "update_template")
 
         assert file_info.steps["update_template"]["result"] is None
         assert file_info.steps["update_template"]["msg"] == "No update needed"
         mock_services["MwClientPage"].return_value.edit.assert_not_called()
 
-    def test_step_update_template_with_update(self, mock_services):
-        """Test _step_update_template when update is performed."""
-        mock_services["MwClientPage"].return_value.get_text.return_value = "Template text"
-        mock_services["update_template_page_file_reference"].return_value = "Updated template text"
+    def test_step_update_page_reference_with_update(self, mock_services):
+        """Test _step_update_page_reference when update is performed."""
+        mock_services["MwClientPage"].return_value.get_text.return_value = "Some text"
+        mock_services["MwClientPage"].return_value.exists.return_value = True
+        mock_services["update_template_page_file_reference"].return_value = "Updated text"
         mock_services["MwClientPage"].return_value.edit.return_value = {"success": True}
 
         processor = CropMainFilesWorker(
@@ -622,7 +625,7 @@ class TestCropMainFilesProcessorSteps:
             cropped_filename="File:test (cropped).svg",
         )
 
-        processor._step_update_template(file_info)
+        processor._step_update_page_reference(file_info, "Template:Test", "update_template")
 
         assert file_info.steps["update_template"]["result"] is True
         mock_services["MwClientPage"].return_value.edit.assert_called_once()
@@ -694,6 +697,7 @@ class TestCropMainFilesProcessorHelpers:
         assert file_info.steps["upload_cropped"]["result"] is None
         assert file_info.steps["update_original"]["result"] is None
         assert file_info.steps["update_template"]["result"] is None
+        assert file_info.steps["update_page"]["result"] is None
         assert processor.result["summary"]["skipped"] == 1
         assert file_info.cropped_filename is None
 
@@ -772,8 +776,8 @@ class TestCropMainFilesProcessorProcessTemplate:
         mock_services["MwClientPage"].return_value.exists.return_value = True
         mock_services["update_original_file_text"].return_value = "Updated original"
         mock_services["MwClientPage"].return_value.edit.return_value = {"success": True}
-        mock_services["MwClientPage"].return_value.get_text.return_value = "Template text"
-        mock_services["update_template_page_file_reference"].return_value = "Updated template"
+        mock_services["MwClientPage"].return_value.get_text.return_value = "Some text"
+        mock_services["update_template_page_file_reference"].return_value = "Updated text"
         mock_services["MwClientPage"].return_value.edit.return_value = {"success": True}
 
         processor = CropMainFilesWorker(


### PR DESCRIPTION
This change refactors the `CropMainFilesWorker` to ensure that when a file is cropped, both the template page (e.g., `Template:OWID/Cereal production`) and its corresponding content page (e.g., `OWID/Cereal production`) are updated to reference the new cropped file.

Key changes:
1.  **Generalization of Update Logic**: The `_step_update_template` method in `worker.py` was refactored into `_step_update_page_reference`, which now accepts a dynamic `page_title` and `step_name`. It also includes improved validation for page existence and non-empty content.
2.  **Dual Page Updates**: The `update_file_references` orchestration method now calls `_step_update_page_reference` twice, ensuring both target pages are updated.
3.  **Frontend Enhancements**: Added an "Update Page" column to the background job details view to track the status of content page updates.
4.  **Test Stability**: Fixed a `TypeError` in `tests/conftest.py` related to `typing.Generator` arguments in Python 3.12, ensuring the test suite runs correctly.
5.  **Robustness**: Improved error handling and skipping logic for the new update step in the background worker.

---
*PR created automatically by Jules for task [17866622384887492953](https://jules.google.com/task/17866622384887492953) started by @MrIbrahem*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Update Page" step to the file processing pipeline, enabling improved control and visibility of page updates during file processing
  * Updated interface now displays a new "Update Page" column in the pages table to track step status and progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->