### PR TITLE
Refactor templates to use commons_file_link macro

### DIFF
--- a/src/templates/_macros.html
+++ b/src/templates/_macros.html
@@ -1,8 +1,12 @@
 {# Shared Jinja macros. #}
-{%- macro commons_file_link(filename) -%}
+{%- macro commons_file_link(filename, label="") -%}
 <a href="https://commons.wikimedia.org/wiki/File:{{ filename | replace('File:', '') }}"
-            target="_blank" rel="noopener noreferrer">
-            File:{{ filename | replace('File:', '') }}
+    target="_blank" rel="noopener noreferrer">
+    {% if label %}
+    {{ label }}
+    {% else %}
+    File:{{ filename | replace('File:', '') }}
+    {% endif %}
 </a>
 {%- endmacro -%}
 {%- macro render_step(step) -%}

--- a/src/templates/_macros.html
+++ b/src/templates/_macros.html
@@ -1,6 +1,7 @@
 {# Shared Jinja macros. #}
 {%- macro commons_file_link(filename, label="") -%}
-<a href="https://commons.wikimedia.org/wiki/File:{{ filename | replace('File:', '') }}"
+{% if filename %}
+<a href="https://commons.wikimedia.org/wiki/File:{{ filename | replace('File:', '') | replace(' ', '_') | urlencode }}"
     target="_blank" rel="noopener noreferrer">
     {% if label %}
     {{ label }}
@@ -8,7 +9,9 @@
     File:{{ filename | replace('File:', '') }}
     {% endif %}
 </a>
+{% endif %}
 {%- endmacro -%}
+
 {%- macro render_step(step) -%}
 {% if step %}
 {% if step.result == true or step.result == "updated" %}

--- a/src/templates/explorer/folder.html
+++ b/src/templates/explorer/folder.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_macros.html" import commons_file_link %}
 
 {% block title %}{{ result.title }} - SVG Explorer{% endblock %}
 
@@ -43,10 +44,7 @@
             <span class="text-muted">
                 {% if result.main_file %}
                 Main File:
-                <a href='https://commons.wikimedia.org/wiki/{{ result.main_file }}' target='_blank'
-                    rel='noopener noreferrer'>
-                    {{ result.main_file }}
-                </a>
+                {{ commons_file_link(result.main_file) }}
                 {% if result.languages %}
                 <span class="text-muted">
                     ({{ result.languages }})
@@ -105,9 +103,7 @@
             <ul class="list-group list-group-numbered">
                 {% for title in result.not_downloaded %}
                 <li class="list-group-item">
-                    <a href='https://commons.wikimedia.org/wiki/{{ title }}' target='_blank' rel='noopener noreferrer'>
-                        {{ title }}
-                    </a>
+                    {{ commons_file_link(title) }}
                 </li>
                 {% endfor %}
             </ul>

--- a/src/templates/extract/result.html
+++ b/src/templates/extract/result.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from "_macros.html" import card_header, stats_card %}
+{% from "_macros.html" import card_header, stats_card, commons_file_link %}
 
 {% block title %}Extract SVG Translations{% endblock %}
 
@@ -21,10 +21,7 @@
                         <div class="mb-3">
                             <h3 class="mb-1">
                                 <i class="bi bi-file-earmark-image"></i>
-                                <a href="https://commons.wikimedia.org/wiki/{{ filename | replace(' ', '_') | urlencode }}"
-                                    target="_blank" rel="noopener noreferrer" class="text-decoration-none">
-                                    {{ filename }}
-                                </a>
+                                {{ commons_file_link(filename) }}
                             </h3>
 
                             {% if languages %}

--- a/src/templates/jobs_templates/admin/collect_templates_data/details.html
+++ b/src/templates/jobs_templates/admin/collect_templates_data/details.html
@@ -1,5 +1,5 @@
 {% extends "jobs_templates/admin/base_details.html" %}
-{% from "_macros.html" import card_header, stats_card, render_step %}
+{% from "_macros.html" import card_header, stats_card, render_step, commons_file_link %}
 {% from "jobs_templates/_help_templates/_skipped_table.html" import table_header_to_expand %}
 
 {% block job_info_extra %}
@@ -121,20 +121,14 @@
                             {% if template.steps %}
                             {{ render_step(template.steps.main_file) }}
                             {% else %}
-                            <a href='https://commons.wikimedia.org/wiki/{{ template.new_main_file }}' target='_blank'
-                                rel='noopener noreferrer'>
-                                {{ template.new_main_file }}
-                            </a>
+                            {{ commons_file_link(template.new_main_file) }}
                             {% endif %}
                         </td>
                         <td>
                             {% if template.steps %}
                             {{ render_step(template.steps.last_world_file) }}
                             {% else %}
-                            <a href='https://commons.wikimedia.org/wiki/{{ template.last_world_file }}' target='_blank'
-                                rel='noopener noreferrer'>
-                                {{ template.last_world_file }}
-                            </a>
+                            {{ commons_file_link(template.last_world_file) }}
                             {% endif %}
                         </td>
                         <td>

--- a/src/templates/jobs_templates/admin/crop_main_files/details.html
+++ b/src/templates/jobs_templates/admin/crop_main_files/details.html
@@ -1,5 +1,5 @@
 {% extends "jobs_templates/admin/base_details.html" %}
-{% from "_macros.html" import card_header, stats_card, render_step %}
+{% from "_macros.html" import card_header, stats_card, render_step, commons_file_link %}
 {% from "jobs_templates/_help_templates/_skipped_table.html" import table_header_to_expand %}
 
 {# Processed files or pages fallback #}
@@ -80,17 +80,11 @@
                             </a>
                         </td>
                         <td>
-                            <a href="https://commons.wikimedia.org/wiki/{{ file.original_file }}" target="_blank"
-                                rel="noopener noreferrer">
-                                File
-                            </a>
+                            {{ commons_file_link(file.original_file, label="File") }}
                         </td>
                         <td>
                             {% if file.cropped_filename and (file.status == 'uploaded' or file.status == 'skipped') %}
-                            <a href="https://commons.wikimedia.org/wiki/{{ file.cropped_filename }}" target="_blank"
-                                rel="noopener noreferrer">
-                                Cropped
-                            </a>
+                            {{ commons_file_link(file.cropped_filename, label="Cropped") }}
                             {% endif %}
                         </td>
                         <td>

--- a/src/templates/jobs_templates/admin/download_main_files/details.html
+++ b/src/templates/jobs_templates/admin/download_main_files/details.html
@@ -1,5 +1,5 @@
 {% extends "jobs_templates/admin/base_details.html" %}
-{% from "_macros.html" import card_header, stats_card %}
+{% from "_macros.html" import card_header, stats_card, commons_file_link %}
 
 {% block job_info_extra %}
 <tr>
@@ -52,10 +52,7 @@
                     <tr>
                         <td>{{ file.template_id }}</td>
                         <td>
-                            <a href='https://commons.wikimedia.org/wiki/{{ file.filename }}' target='_blank'
-                                rel='noopener noreferrer'>
-                                {{ file.filename }}
-                            </a>
+                            {{ commons_file_link(file.filename) }}
                         </td>
                         <td>
                             <a href="{{ url_for('jobs_utils.serve_download_main_file', filename=file.path) }}"

--- a/src/templates/jobs_templates/admin/fix_nested_main_files/details.html
+++ b/src/templates/jobs_templates/admin/fix_nested_main_files/details.html
@@ -1,5 +1,5 @@
 {% extends "jobs_templates/admin/base_details.html" %}
-{% from "_macros.html" import card_header, stats_card %}
+{% from "_macros.html" import card_header, stats_card, commons_file_link %}
 
 {% block job_summary %}
 <div class="row g-3 mb-4">
@@ -52,10 +52,7 @@
                         </td>
                         <td>
                             {% if template.main_file %}
-                            <a href='https://commons.wikimedia.org/wiki/{{ template.main_file | replace("File:", "") }}' target='_blank'
-                                rel='noopener noreferrer'>
-                                {{ template.main_file | replace("File:", "") }}
-                            </a>
+                            {{ commons_file_link(template.main_file) }}
                             {% endif %}
                         </td>
                         <td>{{ template.fix_result.message }}</td>
@@ -96,10 +93,7 @@
                         </td>
                         <td>
                             {% if template.main_file %}
-                            <a href='https://commons.wikimedia.org/wiki/{{ template.main_file | replace("File:", "") }}' target='_blank'
-                                rel='noopener noreferrer'>
-                                {{ template.main_file | replace("File:", "") }}
-                            </a>
+                            {{ commons_file_link(template.main_file) }}
                             {% endif %}
                         </td>
                         <td>{{ template.reason or template.error or template.message }}</td>

--- a/src/templates/jobs_templates/public/copy_svg_langs/details.html
+++ b/src/templates/jobs_templates/public/copy_svg_langs/details.html
@@ -1,5 +1,5 @@
 {% extends "jobs_templates/base_details_public.html" %}
-{% from "_macros.html" import card_header, stats_card, status_icon %}
+{% from "_macros.html" import card_header, stats_card, status_icon, commons_file_link %}
 
 {% block job_info_extra %}
 {% if result_data and result_data.title %}
@@ -78,10 +78,8 @@
                     <tr>
                         <td> {{ loop.index }} </td>
                         <td>
-                            <a href="https://commons.wikimedia.org/wiki/File:{{ item.title }}" target="_blank"
-                                rel="noopener noreferrer">
-                                {{ item.title[:50] }}{% if item.title|length > 50 %}...{% endif %}
-                            </a>
+                            {% set short_title = item.title[:50] ~ '...' if item.title|length > 50 else item.title %}
+                            {{ commons_file_link(item.title, label=short_title) }}
                         </td>
                         <td>
                             {{ status_icon(item.status) }}

--- a/src/templates/jobs_templates/public/fix_nested_jobs/details.html
+++ b/src/templates/jobs_templates/public/fix_nested_jobs/details.html
@@ -1,5 +1,5 @@
 {% extends "jobs_templates/base_details_public.html" %}
-{% from "_macros.html" import card_header, stats_card, status_icon %}
+{% from "_macros.html" import card_header, stats_card, status_icon, commons_file_link %}
 
 {% block job_info_extra %}
 
@@ -7,10 +7,7 @@
 <tr>
     <th>File:</th>
     <td>
-        <a href="https://commons.wikimedia.org/wiki/File:{{ result_data.filename | replace("File:", "") }}"
-            target="_blank" rel="noopener noreferrer">
-            File:{{ result_data.filename | replace("File:", "") }}
-        </a>
+        {{ commons_file_link(result_data.filename) }}
     </td>
 </tr>
 {% endif %}


### PR DESCRIPTION
Replaced manual Wikimedia Commons file links in several HTML templates with the centralized `commons_file_link` macro from `_macros.html`. The macro was enhanced to support an optional label parameter, allowing for custom link text (e.g., "File", "Cropped", or truncated filenames) while maintaining standardized URL generation logic. Affected templates include job details, SVG explorer, and extraction results.

---
*PR created automatically by Jules for task [12905288601914125176](https://jules.google.com/task/12905288601914125176) started by @MrIbrahem*