### PR TITLE
⚡ Bolt: optimize API routes with single-pass iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,5 @@
+# Bolt's Performance Journal - Critical Learnings
+
+## 2025-07-10 - [Optimization of API Route Aggregations]
+**Learning:** In Flask API routes that return both a data list and summary statistics, using multiple `sum(1 for ...)` calls or separate list comprehensions causes multiple O(N) iterations over the same dataset. For large datasets like OWID charts (which can grow to thousands of entries), this leads to measurable overhead.
+**Action:** Always use a single manual loop to build the result list and increment all summary counters simultaneously. This reduces complexity from O(M*N) to O(N), where M is the number of summary statistics.

--- a/src/main_app/public/api_routes.py
+++ b/src/main_app/public/api_routes.py
@@ -27,15 +27,30 @@ class ApiRoutes:
         def templates_list():
             templates: list[TemplateRecord] = list_templates()
 
-            data = [t.to_dict() for t in templates]
+            # Optimized to iterate over templates only once for both data and summary
+            data: list[dict[str, Any]] = []
+            with_main_file = 0
+            with_last_world_file = 0
+            with_last_world_year = 0
+            with_source = 0
 
-            total = len(templates)
+            for t in templates:
+                data.append(t.to_dict())
+                if t.main_file:
+                    with_main_file += 1
+                if t.last_world_file:
+                    with_last_world_file += 1
+                if t.last_world_year:
+                    with_last_world_year += 1
+                if t.source:
+                    with_source += 1
+
             summary = {
-                "total": total,
-                "with_main_file": sum(1 for t in templates if t.main_file),
-                "with_last_world_file": sum(1 for t in templates if t.last_world_file),
-                "with_last_world_year": sum(1 for t in templates if t.last_world_year),
-                "with_source": sum(1 for t in templates if t.source),
+                "total": len(templates),
+                "with_main_file": with_main_file,
+                "with_last_world_file": with_last_world_file,
+                "with_last_world_year": with_last_world_year,
+                "with_source": with_source,
             }
 
             return jsonify({"data": data, "summary": summary})
@@ -74,47 +89,66 @@ class ApiRoutes:
 
             charts_temps = {c.chart_id: c for c in all_charts_templates}
 
-            def get_tmp_title(chart_id):
-                chart_data = charts_temps.get(chart_id)
-                if chart_data:
-                    return chart_data.template_title
-                return None
-
-            if template_filter == "has_template":
-                charts = [c for c in all_charts if get_tmp_title(c.chart_id)]
-            elif template_filter == "no_template":
-                charts = [c for c in all_charts if not get_tmp_title(c.chart_id)]
-            else:
-                charts = all_charts
-
-            total = len(all_charts)
-            summary = {
-                "total": total,
-                "published": {
-                    "with": sum(1 for c in all_charts if c.is_published),
-                    "without": sum(1 for c in all_charts if not c.is_published),
-                },
-                "template": {
-                    "with": sum(1 for c in all_charts if get_tmp_title(c.chart_id)),
-                    "without": sum(1 for c in all_charts if not get_tmp_title(c.chart_id)),
-                },
-                "map_tab": {
-                    "with": sum(1 for c in all_charts if c.has_map_tab),
-                    "without": sum(1 for c in all_charts if not c.has_map_tab),
-                },
-                "timeline": {
-                    "with": sum(1 for c in all_charts if c.has_timeline),
-                    "without": sum(1 for c in all_charts if not c.has_timeline),
-                },
-            }
-
+            # Optimized to iterate over all_charts only once for summary, filtering, and enrichment
             data: list[dict[str, Any]] = []
-            for c in charts:
-                c_json = c.to_dict()
+            published_with = 0
+            published_without = 0
+            template_with = 0
+            template_without = 0
+            map_tab_with = 0
+            map_tab_without = 0
+            timeline_with = 0
+            timeline_without = 0
+
+            for c in all_charts:
+                # Summary statistics
+                if c.is_published:
+                    published_with += 1
+                else:
+                    published_without += 1
+
                 temp = charts_temps.get(c.chart_id)
-                c_json["template_id"] = temp.template_id if temp else None
-                c_json["template_title"] = temp.template_title if temp else None
-                data.append(c_json)
+                has_template = bool(temp.template_title) if temp else False
+
+                if has_template:
+                    template_with += 1
+                else:
+                    template_without += 1
+
+                if c.has_map_tab:
+                    map_tab_with += 1
+                else:
+                    map_tab_without += 1
+
+                if c.has_timeline:
+                    timeline_with += 1
+                else:
+                    timeline_without += 1
+
+                # Filtering and enrichment
+                include_in_data = False
+                if template_filter == "has_template":
+                    if has_template:
+                        include_in_data = True
+                elif template_filter == "no_template":
+                    if not has_template:
+                        include_in_data = True
+                else:
+                    include_in_data = True
+
+                if include_in_data:
+                    c_json = c.to_dict()
+                    c_json["template_id"] = temp.template_id if temp else None
+                    c_json["template_title"] = temp.template_title if temp else None
+                    data.append(c_json)
+
+            summary = {
+                "total": len(all_charts),
+                "published": {"with": published_with, "without": published_without},
+                "template": {"with": template_with, "without": template_without},
+                "map_tab": {"with": map_tab_with, "without": map_tab_without},
+                "timeline": {"with": timeline_with, "without": timeline_without},
+            }
 
             return jsonify({"data": data, "summary": summary, "selected_template": template_filter})
 


### PR DESCRIPTION
### 💡 What: The optimization implemented
Refactored the `/templates` and `/owidcharts` API routes in `src/main_app/public/api_routes.py` to use a single-pass iteration (O(N)) for both data preparation and summary statistics aggregation.

### 🎯 Why: The performance problem it solves
Previously, these routes performed multiple O(N) iterations over the same data collection:
- `templates_list`: 1 iteration for `to_dict()` + 4 `sum()` calls = 5 iterations.
- `owid_charts_list`: 1 iteration for filtering + 8 `sum()` calls + 1 iteration for enrichment = ~10 iterations.
For large datasets, this redundancy causes measurable processing overhead.

### 📊 Impact: Expected performance improvement
- Redundant iterations reduced by ~80-90% in these endpoints.
- Time complexity reduced from O(M*N) to O(N).
- Lower CPU usage and faster response times for metadata-heavy dashboards.

### 🔬 Measurement: How to verify the improvement
- Verified with existing unit tests in `tests/unit/public/test_api_routes.py` (all passed).
- Inspection of `src/main_app/public/api_routes.py` confirms single-loop logic.

---
*PR created automatically by Jules for task [12618857952608400269](https://jules.google.com/task/12618857952608400269) started by @MrIbrahem*