### PR TITLE
Add count_charts function to optimize chart counting

### DIFF
--- a/src/main_app/db/create_helper.py
+++ b/src/main_app/db/create_helper.py
@@ -22,6 +22,7 @@ def create_tables(_db: SQLAlchemy) -> None:
     except SQLAlchemyError as exc:
         raise DatabaseInitError(f"Failed to create tables: {exc}") from exc
 
+
 def create_views(_db: SQLAlchemy) -> None:
     from sqlalchemy import inspect as sa_inspect
 
@@ -52,6 +53,7 @@ def create_views(_db: SQLAlchemy) -> None:
                     conn.execute(text(create_sql))
             except Exception:
                 logger.error("Failed to create view %s", table.name)
+
 
 __all__ = [
     "create_views",

--- a/src/main_app/db/models/owid_charts.py
+++ b/src/main_app/db/models/owid_charts.py
@@ -75,31 +75,23 @@ class OwidChartRecord(db.Model):  # type: ignore
 
     def to_dict(self) -> dict[str, Any]:
         """Serializes the pure model instance into a dictionary."""
-        data: dict[str, Any] = {}
-        table_keys = [
-            "chart_id",
-            "slug",
-            "title",
-            "has_map_tab",
-            "max_time",
-            "min_time",
-            "default_tab",
-            "owid_variable_id",
-            "is_published",
-            "single_year_data",
-            "len_years",
-            "has_timeline",
-            "status_404",
-            "created_at",
-            "updated_at",
-        ]
-        for column in table_keys:
-            value = getattr(self, column)
-            if hasattr(value, "isoformat"):
-                value = value.isoformat()
-            data[column] = value
-
-        return data
+        return {
+            "chart_id": self.chart_id,
+            "slug": self.slug,
+            "title": self.title,
+            "has_map_tab": self.has_map_tab,
+            "max_time": self.max_time,
+            "min_time": self.min_time,
+            "default_tab": self.default_tab,
+            "owid_variable_id": self.owid_variable_id,
+            "is_published": self.is_published,
+            "single_year_data": self.single_year_data,
+            "len_years": self.len_years,
+            "has_timeline": self.has_timeline,
+            "status_404": self.status_404,
+            "created_at": self.created_at.isoformat() if hasattr(self.created_at, "isoformat") else self.created_at,
+            "updated_at": self.updated_at.isoformat() if hasattr(self.updated_at, "isoformat") else self.updated_at,
+        }
 
 
 __all__ = [

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -33,6 +33,7 @@ from .jobs_service import (
 from .owid_charts_service import (
     OwidChartsService,
     add_chart,
+    count_charts,
     get_chart_by_id,
     get_chart_by_slug,
     list_charts,
@@ -149,6 +150,7 @@ __all__ = [
     "add_chart",
     "update_chart_data",
     "list_charts",
+    "count_charts",
     "list_published_charts",
     # owid_slug_redirects_service
     "add_new_slug_redirect",

--- a/src/main_app/db/services/owid_charts_service.py
+++ b/src/main_app/db/services/owid_charts_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sqlalchemy import func
+
 from ...extensions import db
 from ..models.owid_charts import OwidChartRecord
 from .utils import db_guard_rollback, retry_on_db_disconnect
@@ -24,6 +26,13 @@ def list_charts(limit: int | None = None) -> list[OwidChartRecord]:
         query = query.limit(limit)
 
     return query.all()
+
+
+def count_charts() -> int:
+    """
+    Return the total number of charts.
+    """
+    return db.session.query(func.count(OwidChartRecord.chart_id)).scalar()
 
 
 def list_published_charts() -> list[OwidChartRecord]:
@@ -135,6 +144,9 @@ class OwidChartsService:
     def list_charts(self, limit: int | None = None) -> list[OwidChartRecord]:
         return list_charts(limit)
 
+    def count_charts(self) -> int:
+        return count_charts()
+
     def list_published_charts(self) -> list[OwidChartRecord]:
         return list_published_charts()
 
@@ -168,6 +180,7 @@ __all__ = [
     "get_chart_by_slug",
     "add_chart",
     "list_charts",
+    "count_charts",
     "list_published_charts",
     "update_chart_data",
     "update_chart_data_with_retry",

--- a/src/main_app/public/main_routes/owid_charts_routes.py
+++ b/src/main_app/public/main_routes/owid_charts_routes.py
@@ -9,7 +9,7 @@ from flask import (
     render_template,
 )
 
-from ...db.services import list_charts, list_published_charts
+from ...db.services import count_charts, list_charts, list_published_charts
 
 logger = logging.getLogger(__name__)
 
@@ -24,12 +24,9 @@ class OwidChartsRoutes:
         def index() -> str:
             """Display a list of all published OWID charts."""
             charts = list_published_charts()
-            all_charts = list_charts()
+            total_charts = count_charts()
 
-            logger.info(f"Public charts page: {len(charts)} published, {len(all_charts)} total")
-
-            for chart in charts:
-                logger.debug(f"  Published chart: {chart.slug} - {chart.title}")
+            logger.info(f"Public charts page: {len(charts)} published, {total_charts} total")
 
             return render_template("owid_charts/index.html", charts=charts)
 

--- a/tests/integration/public/main_routes/test_owid_charts_routes_integration.py
+++ b/tests/integration/public/main_routes/test_owid_charts_routes_integration.py
@@ -52,9 +52,11 @@ def owid_charts_client(sample_chart, sample_unpublished_chart):
     with (
         patch("src.main_app.public.main_routes.owid_charts_routes.list_published_charts") as mock_published,
         patch("src.main_app.public.main_routes.owid_charts_routes.list_charts") as mock_all,
+        patch("src.main_app.public.main_routes.owid_charts_routes.count_charts") as mock_count,
     ):
         mock_published.return_value = [sample_chart]
         mock_all.return_value = [sample_chart, sample_unpublished_chart]
+        mock_count.return_value = 2
 
         from src.main_app import create_app
 
@@ -62,7 +64,7 @@ def owid_charts_client(sample_chart, sample_unpublished_chart):
         flask_app.config["TESTING"] = True
         flask_app.config["WTF_CSRF_ENABLED"] = False
 
-        yield flask_app.test_client(), mock_published, mock_all
+        yield flask_app.test_client(), mock_published, mock_all, mock_count
 
 
 class TestIndexRoute:
@@ -70,20 +72,20 @@ class TestIndexRoute:
 
     def test_index_renders_with_published_charts(self, owid_charts_client):
         """Test index page renders with published charts."""
-        flask_client, mock_published, _ = owid_charts_client
+        flask_client, mock_published, _, _ = owid_charts_client
 
         response = flask_client.get("/owidcharts/")
 
         assert response.status_code == 200
         mock_published.assert_called_once()
 
-    def test_index_calls_list_charts(self, owid_charts_client):
-        """Test index page also calls list_charts for total count."""
-        flask_client, _, mock_all = owid_charts_client
+    def test_index_calls_count_charts(self, owid_charts_client):
+        """Test index page also calls count_charts for total count."""
+        flask_client, _, _, mock_count = owid_charts_client
 
         flask_client.get("/owidcharts/")
 
-        mock_all.assert_called_once()
+        mock_count.assert_called_once()
 
 
 class TestAllChartsRoute:
@@ -91,7 +93,7 @@ class TestAllChartsRoute:
 
     def test_all_charts_renders(self, owid_charts_client):
         """Test all charts page renders."""
-        flask_client, _, mock_all = owid_charts_client
+        flask_client, _, mock_all, _ = owid_charts_client
 
         response = flask_client.get("/owidcharts/all")
 
@@ -100,7 +102,7 @@ class TestAllChartsRoute:
 
     def test_all_charts_includes_unpublished(self, owid_charts_client, sample_unpublished_chart):
         """Test all charts page includes unpublished charts."""
-        flask_client, _, mock_all = owid_charts_client
+        flask_client, _, mock_all, _ = owid_charts_client
         mock_all.return_value = [sample_unpublished_chart]
 
         response = flask_client.get("/owidcharts/all")
@@ -109,7 +111,7 @@ class TestAllChartsRoute:
 
     def test_all_charts_empty_list(self, owid_charts_client):
         """Test all charts page with no charts."""
-        flask_client, _, mock_all = owid_charts_client
+        flask_client, _, mock_all, _ = owid_charts_client
         mock_all.return_value = []
 
         response = flask_client.get("/owidcharts/all")

--- a/tests/unit/db/services/test_owid_charts_service.py
+++ b/tests/unit/db/services/test_owid_charts_service.py
@@ -11,6 +11,7 @@ import pytest
 from src.main_app.db.services.delete_service import delete_chart
 from src.main_app.db.services.owid_charts_service import (
     add_chart,
+    count_charts,
     get_chart_by_id,
     get_chart_by_slug,
     list_charts,
@@ -56,6 +57,15 @@ def _mock_query_for_read(monkeypatch, **kwargs):
         lambda cls: mock_query,
     )
     return mock_query
+
+
+class TestCountCharts:
+    """Tests for count_charts function."""
+
+    def test_returns_count(self, monkeypatch):
+        """Return the total number of charts."""
+        _mock_query_for_read(monkeypatch, scalar=MagicMock(return_value=42))
+        assert count_charts() == 42
 
 
 class TestListCharts:


### PR DESCRIPTION
Introduce a dedicated count_charts() function that uses SQLAlchemy's count() aggregation instead of loading all chart records into memory. This improves performance when only the total count is needed. Also refactored OwidChartRecord.to_dict() to be more concise and removed unnecessary debug logging in the charts route.