### PR TITLE
⚡ Bolt: Optimize chart and template association queries using SQLAlchemy outerjoin

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-15 - [SQL Joins Over In-Memory Lookups]
+**Learning:** Consolidating multiple database queries (e.g. querying a table and a view separately) into a single SQLAlchemy query using `outerjoin` is extremely efficient. It completely eliminates extra database round-trips, reduces in-memory hash map lookup construction overhead, and leverages database-level optimizations.
+**Action:** When joining tables or views on slug/id, design a single SQLAlchemy query utilizing explicit `.outerjoin()` instead of executing multiple queries and merging result dictionaries in python.

--- a/src/main_app/admin/routes/owid_charts.py
+++ b/src/main_app/admin/routes/owid_charts.py
@@ -72,9 +72,26 @@ class OwidCharts:
             string with appropriate status code (404 for no charts, 500 for errors).
         """
         try:
-            charts: list[OwidChartRecord] = self.owid_charts_service.list_charts()
+            charts_with_templates = self.owid_charts_service.list_charts_with_templates()
 
-            charts_data: list[dict[str, Any]] = get_charts_data(charts)
+            charts_data: list[dict[str, Any]] = []
+            for chart, temp_id, temp_title in charts_with_templates:
+                chart_data = {
+                    "chart_id": chart.chart_id,
+                    "slug": chart.slug,
+                    "title": chart.title,
+                    "has_map_tab": chart.has_map_tab,
+                    "max_time": chart.max_time,
+                    "min_time": chart.min_time,
+                    "default_tab": chart.default_tab,
+                    "is_published": chart.is_published,
+                    "single_year_data": chart.single_year_data,
+                    "len_years": chart.len_years,
+                    "has_timeline": chart.has_timeline,
+                    "template_id": temp_id,
+                    "template_title": temp_title,
+                }
+                charts_data.append(chart_data)
 
             if not charts_data:
                 return "No charts found to export.", 404

--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -37,6 +37,7 @@ from .owid_charts_service import (
     get_chart_by_id,
     get_chart_by_slug,
     list_charts,
+    list_charts_with_templates,
     list_published_charts,
     update_chart_data,
 )
@@ -150,6 +151,7 @@ __all__ = [
     "add_chart",
     "update_chart_data",
     "list_charts",
+    "list_charts_with_templates",
     "count_charts",
     "list_published_charts",
     # owid_slug_redirects_service

--- a/src/main_app/db/services/owid_charts_service.py
+++ b/src/main_app/db/services/owid_charts_service.py
@@ -28,6 +28,24 @@ def list_charts(limit: int | None = None) -> list[OwidChartRecord]:
     return query.all()
 
 
+def list_charts_with_templates() -> list[tuple[OwidChartRecord, int | None, str | None]]:
+    """
+    Retrieve all charts along with their template ID and title using a single LEFT OUTER JOIN.
+    """
+    from ..models.templates import TemplateRecord
+
+    query = (
+        db.session.query(
+            OwidChartRecord,
+            TemplateRecord.id,
+            TemplateRecord.title,
+        )
+        .outerjoin(TemplateRecord, OwidChartRecord.slug == TemplateRecord.slug)
+        .order_by(OwidChartRecord.chart_id.asc())
+    )
+    return query.all()
+
+
 def count_charts() -> int:
     """
     Return the total number of charts.
@@ -144,6 +162,9 @@ class OwidChartsService:
     def list_charts(self, limit: int | None = None) -> list[OwidChartRecord]:
         return list_charts(limit)
 
+    def list_charts_with_templates(self) -> list[tuple[OwidChartRecord, int | None, str | None]]:
+        return list_charts_with_templates()
+
     def count_charts(self) -> int:
         return count_charts()
 
@@ -180,6 +201,7 @@ __all__ = [
     "get_chart_by_slug",
     "add_chart",
     "list_charts",
+    "list_charts_with_templates",
     "count_charts",
     "list_published_charts",
     "update_chart_data",

--- a/src/main_app/public/api_routes.py
+++ b/src/main_app/public/api_routes.py
@@ -8,6 +8,7 @@ from flask import Blueprint, jsonify
 from ..db.models import OwidChartRecord, OwidChartTemplateView, TemplateRecord
 from ..db.services import (
     list_charts,
+    list_charts_with_templates,
     list_owid_charts_templates,
     list_templates,
     list_templates_mismatched_years,
@@ -24,25 +25,23 @@ class ApiRoutes:
 
     def make_charts_summary(
         self,
-        all_charts: list[OwidChartRecord],
-        charts_temps: dict[int, OwidChartTemplateView],
+        charts_with_templates: list[tuple[OwidChartRecord, int | None, str | None]],
         template_filter: str,
     ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
         data: list[dict[str, Any]] = []
-        total = len(all_charts)
+        total = len(charts_with_templates)
         published_with = 0
         template_with = 0
         map_tab_with = 0
         timeline_with = 0
 
         # Single-pass loop to build data and collect summary statistics
-        for c in all_charts:
+        for c, temp_id, temp_title in charts_with_templates:
             # Update summary metrics
             if c.is_published:
                 published_with += 1
 
-            temp_rec = charts_temps.get(c.chart_id)
-            has_template = bool(temp_rec.template_title) if temp_rec else False
+            has_template = bool(temp_title)
 
             if has_template:
                 template_with += 1
@@ -59,8 +58,8 @@ class ApiRoutes:
             )
             if include:
                 c_json = c.to_dict()
-                c_json["template_id"] = temp_rec.template_id if temp_rec else None
-                c_json["template_title"] = temp_rec.template_title if temp_rec else None
+                c_json["template_id"] = temp_id
+                c_json["template_title"] = temp_title
                 data.append(c_json)
 
         summary = {
@@ -139,12 +138,9 @@ class ApiRoutes:
         @self.bp.get("/owidcharts/")
         @self.bp.get("/owidcharts/<string:template_filter>")
         def owid_charts_list(template_filter: str = ""):
-            all_charts: list[OwidChartRecord] = list_charts()
-            all_charts_templates: list[OwidChartTemplateView] = list_owid_charts_templates()
+            charts_with_templates = list_charts_with_templates()
 
-            charts_temps = {c.chart_id: c for c in all_charts_templates}
-
-            summary, data = self.make_charts_summary(all_charts, charts_temps, template_filter)
+            summary, data = self.make_charts_summary(charts_with_templates, template_filter)
 
             return jsonify({"data": data, "summary": summary, "selected_template": template_filter})
 

--- a/tests/integration/admin/routes/test_owid_charts_integration.py
+++ b/tests/integration/admin/routes/test_owid_charts_integration.py
@@ -89,6 +89,11 @@ def mock_service():
     """Return mock service objects for OWID charts."""
     mocks = MagicMock()
     mocks.list_charts = MagicMock(return_value=[])
+
+    def fake_list_charts_with_templates():
+        return [(chart, None, None) for chart in mocks.list_charts()]
+
+    mocks.list_charts_with_templates = MagicMock(side_effect=fake_list_charts_with_templates)
     mocks.add_chart = MagicMock()
     mocks.update_chart_data = MagicMock()
     mocks.delete_chart = MagicMock()

--- a/tests/unit/admin/routes/test_owid_charts.py
+++ b/tests/unit/admin/routes/test_owid_charts.py
@@ -54,32 +54,28 @@ class TestCreateJsonFile:
         mock_chart.len_years = None
         mock_chart.has_timeline = False
         mock_service = self._setup_service(monkeypatch)
-        mock_service.list_charts.return_value = [mock_chart]
-        monkeypatch.setattr("src.main_app.admin.routes.owid_charts.list_owid_charts_templates", list)
+        mock_service.list_charts_with_templates.return_value = [(mock_chart, None, None)]
         response, status = create_json_file()
         assert status == 200
         assert "owid_charts.json" in response.headers["Content-Disposition"]
 
     def test_no_charts(self, monkeypatch):
         mock_service = self._setup_service(monkeypatch)
-        mock_service.list_charts.return_value = []
-        monkeypatch.setattr("src.main_app.admin.routes.owid_charts.list_owid_charts_templates", list)
+        mock_service.list_charts_with_templates.return_value = []
         msg, status = create_json_file()
         assert status == 404
         assert "No charts found" in msg
 
     def test_lookup_error(self, monkeypatch):
         mock_service = self._setup_service(monkeypatch)
-        mock_service.list_charts.side_effect = LookupError("not found")
-        monkeypatch.setattr("src.main_app.admin.routes.owid_charts.list_owid_charts_templates", list)
+        mock_service.list_charts_with_templates.side_effect = LookupError("not found")
         msg, status = create_json_file()
         assert status == 404
         assert "Charts not found" in msg
 
     def test_exception(self, monkeypatch):
         mock_service = self._setup_service(monkeypatch)
-        mock_service.list_charts.side_effect = RuntimeError("error")
-        monkeypatch.setattr("src.main_app.admin.routes.owid_charts.list_owid_charts_templates", list)
+        mock_service.list_charts_with_templates.side_effect = RuntimeError("error")
         msg, status = create_json_file()
         assert status == 500
         assert "Failed to create JSON file" in msg
@@ -97,13 +93,8 @@ class TestCreateJsonFile:
         mock_chart.single_year_data = False
         mock_chart.len_years = None
         mock_chart.has_timeline = False
-        mock_template = MagicMock()
-        mock_template.chart_id = 1
-        mock_template.template_id = 42
-        mock_template.template_title = "Template:T"
         mock_service = self._setup_service(monkeypatch)
-        mock_service.list_charts.return_value = [mock_chart]
-        monkeypatch.setattr("src.main_app.admin.routes.owid_charts.list_owid_charts_templates", lambda: [mock_template])
+        mock_service.list_charts_with_templates.return_value = [(mock_chart, 42, "Template:T")]
         response, status = create_json_file()
         import json as j
 

--- a/tests/unit/db/services/test_owid_charts_service.py
+++ b/tests/unit/db/services/test_owid_charts_service.py
@@ -15,6 +15,7 @@ from src.main_app.db.services.owid_charts_service import (
     get_chart_by_id,
     get_chart_by_slug,
     list_charts,
+    list_charts_with_templates,
     list_published_charts,
     update_chart_data,
 )
@@ -66,6 +67,33 @@ class TestCountCharts:
         """Return the total number of charts."""
         _mock_query_for_read(monkeypatch, scalar=MagicMock(return_value=42))
         assert count_charts() == 42
+
+
+class TestListChartsWithTemplates:
+    """Tests for list_charts_with_templates function."""
+
+    def test_returns_charts_with_templates(self, monkeypatch):
+        """Return charts and template metadata via outerjoin mock."""
+        mock_chart = MagicMock()
+        mock_chart.slug = "chart-slug"
+
+        # mock db.session.query to return a mock query that can be chained
+        mock_query = MagicMock()
+        mock_query.outerjoin.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.all.return_value = [(mock_chart, 123, "Template Title")]
+
+        monkeypatch.setattr(
+            "src.main_app.db.services.owid_charts_service.db.session.query",
+            lambda *args: mock_query,
+        )
+
+        result = list_charts_with_templates()
+        assert len(result) == 1
+        chart, temp_id, temp_title = result[0]
+        assert chart is mock_chart
+        assert temp_id == 123
+        assert temp_title == "Template Title"
 
 
 class TestListCharts:

--- a/tests/unit/public/test_api_routes.py
+++ b/tests/unit/public/test_api_routes.py
@@ -188,13 +188,20 @@ class TestOwidChartsList:
         ct3 = _make_chart_template_mock(chart_id=3, template_id=None, template_title=None)
         self.chart_templates = [ct1, ct3]
 
+        # For list_charts_with_templates, map each chart to its corresponding template_id/title
+        def fake_list_charts_with_templates():
+            temps_map = {ct.chart_id: ct for ct in self.chart_templates}
+            result = []
+            for c in self.charts:
+                temp = temps_map.get(c.chart_id)
+                temp_id = temp.template_id if temp else None
+                temp_title = temp.template_title if temp else None
+                result.append((c, temp_id, temp_title))
+            return result
+
         monkeypatch.setattr(
-            "src.main_app.public.api_routes.list_charts",
-            lambda: self.charts,
-        )
-        monkeypatch.setattr(
-            "src.main_app.public.api_routes.list_owid_charts_templates",
-            lambda: self.chart_templates,
+            "src.main_app.public.api_routes.list_charts_with_templates",
+            fake_list_charts_with_templates,
         )
 
     def test_owid_charts_list_no_filter(self, mock_client: FlaskClient) -> None:


### PR DESCRIPTION
Optimizes `owid_charts_list` and `create_json_file` by fetching chart and template records combined in a single database query using an SQLAlchemy `outerjoin` instead of executing multiple queries and performing in-memory dictionary joins.

Expected Impact:
- Combines 2 queries into 1 on the database.
- Completely eliminates in-memory dictionary join mapping templates to charts.
- Reduces endpoint load times significantly.

---
*PR created automatically by Jules for task [10520605736181448023](https://jules.google.com/task/10520605736181448023) started by @MrIbrahem*