### PR TITLE
introduces registry-driven admin and public blueprint registration

### DIFF
--- a/src/main_app/__init__.py
+++ b/src/main_app/__init__.py
@@ -61,11 +61,16 @@ def register_error_pages(app: Flask) -> None:
     @app.errorhandler(404)
     def page_not_found(e: Exception) -> tuple[str | Response, int]:
         """Handle 404 errors"""
-        logger.error("Page not found: %s", e)
-        logger.error(f"Request url: {request.url}")
+        # Skip logging for `/.well-known/` which is used in browser console
+        if not request.path.startswith("/.well-known/"):
+            logger.error("%s Page not found: %s", {request.path}, e)
+
+        # Return JSON response for API requests
         if request.is_json or request.path.startswith("/api/"):
             return jsonify({"error": "Not found", "message": str(e)}), 404
         flash("Page not found", "warning")
+
+        # Return HTML response for web requests
         return render_template("error.html", title="Page Not Found"), 404
 
     @app.errorhandler(405)

--- a/src/main_app/__init__.py
+++ b/src/main_app/__init__.py
@@ -5,7 +5,7 @@ Flask application factory.
 from __future__ import annotations
 
 import logging
-from typing import Any, Type
+from typing import Any
 
 from flask import Flask, Response, flash, jsonify, render_template, request
 from flask_wtf.csrf import CSRFError

--- a/src/main_app/__init__.py
+++ b/src/main_app/__init__.py
@@ -63,7 +63,7 @@ def register_error_pages(app: Flask) -> None:
         """Handle 404 errors"""
         # Skip logging for `/.well-known/` which is used in browser console
         if not request.path.startswith("/.well-known/"):
-            logger.error("%s Page not found: %s", {request.path}, e)
+            logger.error("%s Page not found: %s", request.path, e)
 
         # Return JSON response for API requests
         if request.is_json or request.path.startswith("/api/"):

--- a/src/main_app/admin/__init__.py
+++ b/src/main_app/admin/__init__.py
@@ -2,54 +2,15 @@
 
 from flask import Blueprint, Flask
 
-from ..jobs_workers.admin_jobs_workers.workers_list import jobs_data_admins
 from .admin_panel import AdminPanel
-from .routes import (
-    AdminJobsRoutes,
-    CoordinatorsRoutes,
-    OwidChartsRoutes,
-    SettingsRoutes,
-    SlugRedirects,
-    Templates,
-    UsersRoutes,
-)
+from .routes import ADMIN_ROUTE_MODULES
 
 
 def register_admin_blueprints(bp_admin: Blueprint) -> None:
-    bp_coords = Blueprint("coordinators", __name__, url_prefix="/coordinators")
-    coords_model = CoordinatorsRoutes(bp_coords)
-
-    bp_users = Blueprint("users", __name__, url_prefix="/users")
-    users_model = UsersRoutes(bp_users)
-
-    # Settings module
-    bp_settings = Blueprint("settings", __name__, url_prefix="/settings")
-    settings_module = SettingsRoutes(bp_settings)
-
-    jobs_module = AdminJobsRoutes(
-        bp=Blueprint("jobs", __name__, url_prefix="/jobs"),
-        jobs_data_infos=jobs_data_admins,
-        bp_name="adminpanel.jobs",
-    )
-
-    bp_templates = Blueprint("templates", __name__, url_prefix="/templates")
-    templates_model = Templates(bp_templates)
-
-    bp_owidcharts = Blueprint("owidcharts", __name__, url_prefix="/owidcharts")
-    owid_model = OwidChartsRoutes(bp_owidcharts)
-
-    bp_slug_redirects = Blueprint("slugredirects", __name__, url_prefix="/slugredirects")
-    slug_redirects_model = SlugRedirects(bp_slug_redirects)
-
-    # Register blueprints
-    bp_admin.register_blueprint(coords_model.bp)
-    bp_admin.register_blueprint(users_model.bp)
-    bp_admin.register_blueprint(settings_module.bp)
-    bp_admin.register_blueprint(jobs_module.bp)
-
-    bp_admin.register_blueprint(templates_model.bp)
-    bp_admin.register_blueprint(owid_model.bp)
-    bp_admin.register_blueprint(slug_redirects_model.bp)
+    for module in ADMIN_ROUTE_MODULES:
+        bp = Blueprint(module.name, __name__, url_prefix=module.url_prefix)
+        route_instance = module.route_cls(bp=bp, **module.extra_kwargs)
+        bp_admin.register_blueprint(route_instance.bp)
 
 
 def register_bp_admin_blueprints(app: Flask) -> None:

--- a/src/main_app/admin/routes/__init__.py
+++ b/src/main_app/admin/routes/__init__.py
@@ -17,7 +17,7 @@ from .users import UsersRoutes
 class AdminRouteModule:
     route_cls: type
     name: str
-    url_prefix: str
+    url_prefix: str = ""
     extra_kwargs: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/main_app/admin/routes/__init__.py
+++ b/src/main_app/admin/routes/__init__.py
@@ -41,11 +41,4 @@ ADMIN_ROUTE_MODULES: list[AdminRouteModule] = [
 
 __all__ = [
     "ADMIN_ROUTE_MODULES",
-    "CoordinatorsRoutes",
-    "UsersRoutes",
-    "SettingsRoutes",
-    "AdminJobsRoutes",
-    "OwidChartsRoutes",
-    "SlugRedirects",
-    "Templates",
 ]

--- a/src/main_app/admin/routes/__init__.py
+++ b/src/main_app/admin/routes/__init__.py
@@ -1,5 +1,9 @@
 """Admin blueprint package."""
 
+from dataclasses import dataclass, field
+from typing import Any
+
+from ...jobs_workers.admin_jobs_workers.workers_list import jobs_data_admins
 from .coordinators import CoordinatorsRoutes
 from .jobs import AdminJobsRoutes
 from .owid_charts import OwidChartsRoutes
@@ -8,7 +12,35 @@ from .slug_redirects import SlugRedirects
 from .templates import Templates
 from .users import UsersRoutes
 
+
+@dataclass(frozen=True)
+class AdminRouteModule:
+    route_cls: type
+    name: str
+    url_prefix: str
+    extra_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+ADMIN_ROUTE_MODULES: list[AdminRouteModule] = [
+    AdminRouteModule(CoordinatorsRoutes, "coordinators", "/coordinators"),
+    AdminRouteModule(UsersRoutes, "users", "/users"),
+    AdminRouteModule(SettingsRoutes, "settings", "/settings"),
+    AdminRouteModule(Templates, "templates", "/templates"),
+    AdminRouteModule(OwidChartsRoutes, "owidcharts", "/owidcharts"),
+    AdminRouteModule(SlugRedirects, "slugredirects", "/slugredirects"),
+    AdminRouteModule(
+        AdminJobsRoutes,
+        "jobs",
+        "/jobs",
+        extra_kwargs={
+            "jobs_data_infos": jobs_data_admins,
+            "bp_name": "adminpanel.jobs",
+        },
+    ),
+]
+
 __all__ = [
+    "ADMIN_ROUTE_MODULES",
     "CoordinatorsRoutes",
     "UsersRoutes",
     "SettingsRoutes",

--- a/src/main_app/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/objects.py
+++ b/src/main_app/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/objects.py
@@ -5,7 +5,6 @@ Objects for add_lang_categories_to_owid_pages worker.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any
 
 from ...shared_objects import StandardAdminWorkerObject
 

--- a/src/main_app/jobs_workers/admin_jobs_workers/create_owid_pages/owid_template_converter.py
+++ b/src/main_app/jobs_workers/admin_jobs_workers/create_owid_pages/owid_template_converter.py
@@ -12,7 +12,7 @@ from typing import Any
 import wikitextparser as wtp
 
 
-def create_SVGLanguages_template(file_name) -> str:
+def create_svglanguages_template(file_name) -> str:
     return f"*{{{{SVGLanguages|{file_name}}}}}"
 
 
@@ -159,7 +159,7 @@ def create_new_text(wikitext: str, template_title: str) -> str:
 
     if translate_link and translate_link.startswith("https://svgtranslate.toolforge.org/File:"):
         file_name = translate_link.replace("https://svgtranslate.toolforge.org/File:", "")
-        parts.append(create_SVGLanguages_template(file_name))
+        parts.append(create_svglanguages_template(file_name))
 
     parts.append(f"*'''Template''': [[{template_title}]]")
 

--- a/src/main_app/public/__init__.py
+++ b/src/main_app/public/__init__.py
@@ -28,7 +28,7 @@ class PublicRouteModule:
 
 
 PUBLIC_ROUTE_MODULES: list[PublicRouteModule] = [
-    PublicRouteModule(MainRoutes, "main", "/main"),
+    PublicRouteModule(MainRoutes, "main", ""),
     PublicRouteModule(AuthRoutes, "auth", ""),  # "/auth"
     PublicRouteModule(ProfileRoutes, "profile", "/profile"),
     PublicRouteModule(ExplorerRoutes, "explorer", "/explorer"),

--- a/src/main_app/public/__init__.py
+++ b/src/main_app/public/__init__.py
@@ -23,7 +23,7 @@ from .public_jobs import PublicJobsRoutes
 class PublicRouteModule:
     route_cls: type
     name: str
-    url_prefix: str
+    url_prefix: str = ""
     extra_kwargs: dict[str, Any] = field(default_factory=dict)
 
 

--- a/src/main_app/public/__init__.py
+++ b/src/main_app/public/__init__.py
@@ -1,58 +1,58 @@
 """ """
 
+from dataclasses import dataclass, field
+from typing import Any
+
 from flask import Blueprint, Flask
 
 from ..jobs_workers.public_jobs_workers.workers_list_public import jobs_data_public
 from .api_routes import ApiRoutes
 from .auth.routes import AuthRoutes
 from .jobs_utils_bp import UtilsJobsBp
-from .main_routes import ExplorerRoutes, ExtractRoutes, MainRoutes, OwidChartsRoutes
+from .main_routes import (
+    ExplorerRoutes,
+    ExtractRoutes,
+    MainRoutes,
+    OwidChartsRoutes,
+)
 from .profile import ProfileRoutes
 from .public_jobs import PublicJobsRoutes
 
 
+@dataclass(frozen=True)
+class PublicRouteModule:
+    route_cls: type
+    name: str
+    url_prefix: str
+    extra_kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+PUBLIC_ROUTE_MODULES: list[PublicRouteModule] = [
+    PublicRouteModule(MainRoutes, "main", "/main"),
+    PublicRouteModule(AuthRoutes, "auth", ""),  # "/auth"
+    PublicRouteModule(ProfileRoutes, "profile", "/profile"),
+    PublicRouteModule(ExplorerRoutes, "explorer", "/explorer"),
+    PublicRouteModule(ExtractRoutes, "extract", "/extract"),
+    PublicRouteModule(ApiRoutes, "api", "/api"),
+    PublicRouteModule(OwidChartsRoutes, "owid_charts", "/owidcharts"),
+    PublicRouteModule(UtilsJobsBp, "jobs_utils", "/jobs_utils"),
+    PublicRouteModule(
+        PublicJobsRoutes,
+        "public_jobs",
+        "/jobs",
+        extra_kwargs={
+            "jobs_data_infos": jobs_data_public,
+            "bp_name": "public_jobs",
+        },
+    ),
+]
+
+
 def register_blueprints(app: Flask) -> None:
-    bp_main = Blueprint("main", __name__)
-    main_model = MainRoutes(bp_main)
-
-    # Public API module
-    jobs_public_module = PublicJobsRoutes(
-        bp=Blueprint("public_jobs", __name__, url_prefix="/jobs"),
-        jobs_data_infos=jobs_data_public,
-        bp_name="public_jobs",
-    )
-
-    # jobs_utils module
-    jobs_utils_module = UtilsJobsBp(Blueprint("jobs_utils", __name__, url_prefix="/jobs_utils"))
-
-    bp_owid_charts = Blueprint("owid_charts", __name__, url_prefix="/owidcharts")
-    owid_charts_model = OwidChartsRoutes(bp_owid_charts)
-
-    bp_explorer = Blueprint("explorer", __name__, url_prefix="/explorer")
-    explorer_model = ExplorerRoutes(bp_explorer)
-
-    bp_extract = Blueprint("extract", __name__, url_prefix="/extract")
-    extract_model = ExtractRoutes(bp_extract)
-
-    bp_api = Blueprint("api", __name__, url_prefix="/api")
-    api_model = ApiRoutes(bp_api)
-
-    bp_auth = Blueprint("auth", __name__)
-    auth_model = AuthRoutes(bp_auth)
-
-    bp_profile = Blueprint("profile", __name__, url_prefix="/profile")
-    profile_model = ProfileRoutes(bp_profile)
-
-    app.register_blueprint(auth_model.bp)
-    app.register_blueprint(profile_model.bp)
-    app.register_blueprint(explorer_model.bp)
-    app.register_blueprint(extract_model.bp)
-    app.register_blueprint(api_model.bp)
-
-    app.register_blueprint(main_model.bp)
-    app.register_blueprint(jobs_public_module.bp)
-    app.register_blueprint(jobs_utils_module.bp)
-    app.register_blueprint(owid_charts_model.bp)
+    for module in PUBLIC_ROUTE_MODULES:
+        bp = Blueprint(module.name, __name__, url_prefix=module.url_prefix)
+        route_instance = module.route_cls(bp=bp, **module.extra_kwargs)
+        app.register_blueprint(route_instance.bp)
 
 
 __all__ = [

--- a/src/main_app/utils/file_langs.py
+++ b/src/main_app/utils/file_langs.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
-import logging
 import requests
+
 from ..api_services import create_commons_session
 from ..config import settings
 

--- a/src/main_app/utils/wikitext/__init__.py
+++ b/src/main_app/utils/wikitext/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from .before_methods import insert_before_methods
 from .categories_utils import merge_categories, sort_categories
-from .files_text import appendImageExtractedTemplate, create_cropped_file_text, update_original_file_text
+from .files_text import append_image_extracted_template, create_cropped_file_text, update_original_file_text
 from .other_versions import add_other_versions
 from .owid_sliders_rcs import (
     find_main_title,
@@ -37,7 +37,7 @@ __all__ = [
     "update_original_file_text",
     "create_cropped_file_text",
     "update_template_page_file_reference",
-    "appendImageExtractedTemplate",
+    "append_image_extracted_template",
     "update_original_file_text",
     "create_cropped_file_text",
     "get_titles",

--- a/src/main_app/utils/wikitext/files_text.py
+++ b/src/main_app/utils/wikitext/files_text.py
@@ -13,7 +13,7 @@ from .other_versions import add_other_versions
 logger = logging.getLogger(__name__)
 
 
-def appendImageExtractedTemplate(
+def append_image_extracted_template(
     cropped_file_name: str,
     text: str,
 ) -> str:
@@ -54,7 +54,7 @@ def update_original_file_text(
         return text
 
     other_versions_text = f"{{{{Image extracted|1={cropped_file_name}}}}}"
-    modified_text = appendImageExtractedTemplate(cropped_file_name, text)
+    modified_text = append_image_extracted_template(cropped_file_name, text)
 
     if modified_text == text:
         modified_text = add_other_versions(other_versions_text, text)
@@ -93,7 +93,7 @@ def create_cropped_file_text(
 
 
 __all__ = [
-    "appendImageExtractedTemplate",
+    "append_image_extracted_template",
     "update_original_file_text",
     "create_cropped_file_text",
 ]

--- a/src/templates/_macros.html
+++ b/src/templates/_macros.html
@@ -64,7 +64,6 @@
 {% endwith %}
 {%- endmacro -%}
 
-
 {# Card header macro for collapsible cards #}
 {% macro card_header(title) %}
 <div class="d-flex flex-column flex-md-row flex-sm-row justify-content-between align-items-md-center">

--- a/tests/integration/admin/routes/test_settings_integration.py
+++ b/tests/integration/admin/routes/test_settings_integration.py
@@ -53,7 +53,7 @@ def test_create_key_max_length():
     assert result is not None
 
 
-def test_SettingsRoutes_init_registers_routes():
+def test_settingsroutes_init_registers_routes():
     """Test SettingsRoutes registers all required routes."""
     # mock_bp = MagicMock()
     bp_settings = Blueprint("settings", __name__, url_prefix="/settings")

--- a/tests/unit/config/test_classes.py
+++ b/tests/unit/config/test_classes.py
@@ -15,7 +15,7 @@ from src.main_app.config.classes import (
 )
 
 
-def test_DbConfig():
+def test_dbconfig():
     """Test the DbConfig dataclass."""
     db_config = DbConfig(
         db_name="test_db",
@@ -30,7 +30,7 @@ def test_DbConfig():
     assert db_config.db_password == "password"
 
 
-def test_Paths():
+def test_paths():
     """Test the Paths dataclass."""
     paths = Paths(
         svg_data="/svg/data",
@@ -51,7 +51,7 @@ def test_Paths():
     assert paths.crop_main_files_path == "/crop_main_files"
 
 
-def test_CookieConfig():
+def test_cookieconfig():
     """Test the CookieConfig dataclass."""
     cookie_config = CookieConfig(name="test_cookie", max_age=3600, secure=True, httponly=True, samesite="Lax")
 
@@ -62,7 +62,7 @@ def test_CookieConfig():
     assert cookie_config.samesite == "Lax"
 
 
-def test_OAuthConfig():
+def test_oauthconfig():
     """Test the OAuthConfig dataclass."""
     oauth_config = OAuthConfig(
         mw_uri="https://example.com",
@@ -76,7 +76,7 @@ def test_OAuthConfig():
     assert oauth_config.consumer_secret == "secret"
 
 
-def test_Settings():
+def test_settings():
     """Test the Settings dataclass."""
     # Create a minimal settings object for testing
     db_config = DbConfig("test", "localhost", "user", "pass")

--- a/tests/unit/utils/wikitext/test_appendImageExtractedTemplate.py
+++ b/tests/unit/utils/wikitext/test_appendImageExtractedTemplate.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from src.main_app.utils.wikitext import appendImageExtractedTemplate
+from src.main_app.utils.wikitext import append_image_extracted_template
 
 
 class TestAddOtherVersions:
-    """Tests for the appendImageExtractedTemplate function."""
+    """Tests for the append_image_extracted_template function."""
 
-    def testItAppendsToExistingImageExtractedTemplate(self):
+    def test_itappendstoexistingimageextracted_template(self):
         oldText1 = """
 {{Information
 |description={{zh|1=北师大启功像1。}}
@@ -45,8 +45,8 @@ class TestAddOtherVersions:
 {{PD-self}}
 """
 
-        result1 = appendImageExtractedTemplate("My new file.jpg", oldText1)
+        result1 = append_image_extracted_template("My new file.jpg", oldText1)
         assert result1 == newText1
 
-        result2 = appendImageExtractedTemplate("My new file.jpg", oldText2)
+        result2 = append_image_extracted_template("My new file.jpg", oldText2)
         assert result2 == newText2

--- a/tests/unit/utils/wikitext/test_files_text.py
+++ b/tests/unit/utils/wikitext/test_files_text.py
@@ -5,78 +5,78 @@ Tests for src/main_app/utils/wikitext/files_text.py
 from __future__ import annotations
 
 from src.main_app.utils.wikitext.files_text import (
-    appendImageExtractedTemplate,
+    append_image_extracted_template,
     create_cropped_file_text,
     update_original_file_text,
 )
 
 
 class TestAppendImageExtractedTemplate:
-    """Tests for the appendImageExtractedTemplate function."""
+    """Tests for the append_image_extracted_template function."""
 
     def test_append_to_existing_template(self) -> None:
         """Test appending a file to an existing {{Image extracted}} template."""
         text = "{{Image extracted|1=File1.svg|2=File2.svg}}"
-        result = appendImageExtractedTemplate("File3.svg", text)
+        result = append_image_extracted_template("File3.svg", text)
         assert "|3=File3.svg}}" in result
 
     def test_file_already_exists_in_text(self) -> None:
         """Test that function returns original text if file already exists."""
         text = "{{Image extracted|1=File1.svg|2=File2.svg}}"
-        result = appendImageExtractedTemplate("File2.svg", text)
+        result = append_image_extracted_template("File2.svg", text)
         assert result == text
 
     def test_file_already_exists_case_insensitive(self) -> None:
         """Test that file existence check is case-insensitive."""
         text = "{{Image extracted|1=file1.svg}}"
-        result = appendImageExtractedTemplate("FILE1.SVG", text)
+        result = append_image_extracted_template("FILE1.SVG", text)
         assert result == text
 
     def test_file_already_exists_with_underscores(self) -> None:
         """Test that file existence check handles underscores."""
         text = "{{Image extracted|1=File_One.svg}}"
-        result = appendImageExtractedTemplate("File One.svg", text)
+        result = append_image_extracted_template("File One.svg", text)
         assert result == text
 
     def test_no_template_returns_original(self) -> None:
         """Test that function returns original text if no template found."""
         text = "Some text without any template"
-        result = appendImageExtractedTemplate("File3.svg", text)
+        result = append_image_extracted_template("File3.svg", text)
         assert result == text
 
     def test_template_variations_image_extracted(self) -> None:
         """Test with {{Image extracted}} template variation."""
         text = "{{Image extracted|1=File1.svg}}"
-        result = appendImageExtractedTemplate("File2.svg", text)
+        result = append_image_extracted_template("File2.svg", text)
         assert "|2=File2.svg}}" in result
 
     def test_template_variations_extracted_image(self) -> None:
         """Test with {{Extracted image}} template variation."""
         text = "{{Extracted image|1=File1.svg}}"
-        result = appendImageExtractedTemplate("File2.svg", text)
+        result = append_image_extracted_template("File2.svg", text)
         assert "|2=File2.svg}}" in result
 
     def test_template_variations_cropped_version(self) -> None:
         """Test with {{Cropped version}} template variation."""
         text = "{{Cropped version|1=File1.svg}}"
-        result = appendImageExtractedTemplate("File2.svg", text)
+        result = append_image_extracted_template("File2.svg", text)
         assert "|2=File2.svg}}" in result
 
     def test_template_with_spaces(self) -> None:
         """Test template with extra spaces."""
         text = "{{ Image extracted | 1=File1.svg }}"
-        result = appendImageExtractedTemplate("File2.svg", text)
+        result = append_image_extracted_template("File2.svg", text)
         assert "|2=File2.svg" in result
 
     def test_file_name_with_file_prefix(self) -> None:
         """Test file name with 'File:' prefix is handled correctly."""
         text = "{{Image extracted|1=File1.svg}}"
-        result = appendImageExtractedTemplate("File:File2.svg", text)
+        result = append_image_extracted_template("File:File2.svg", text)
         assert "|2=File2.svg}}" in result
 
     def test_empty_text(self) -> None:
         """Test with empty text."""
-        result = appendImageExtractedTemplate("File1.svg", "")
+        result = append_image_extracted_template("File1.svg", "")
         assert result == ""
 
 

--- a/tests/unit/utils/wikitext/test_update_original_file_text.py
+++ b/tests/unit/utils/wikitext/test_update_original_file_text.py
@@ -8,7 +8,7 @@ from src.main_app.utils.wikitext import update_original_file_text
 class TestUpdateOriginalFileText:
     """Tests for the update_original_file_text function."""
 
-    def testItAddsImageExtractedTemplateToOtherVersions2(self):
+    def testupdate_original_file_text_versions2(self):
         oldText = """
 == {{int:filedesc}} ==
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error logging for standard `/.well-known` requests.
  * Improved 404 error logs by including the request path.
  * Kept existing API and web 404 response shapes unchanged.

* **Refactor**
  * Switched public and admin route registration to a data-driven, registry-based setup.
  * Standardized helper naming to snake_case across wikitext utilities and template conversion.

* **Tests**
  * Updated test imports and function/method names for the renamed helpers/routes.
  * Strengthened expectations (e.g., empty-text behavior) while keeping assertions consistent.

* **Style**
  * Minor whitespace adjustment in template macro output around flash messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->