### PR TITLE
Change handling of non-English language detection

### DIFF
--- a/src/main_app/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/worker.py
@@ -187,7 +187,7 @@ class AddLangCategoriesWorker(BaseObjectsJobWorker):
 
         # Step 3 — get_languages
         if not self._step_get_languages(info):
-            self.result.pages_failed.append(info.to_dict())
+            self.result.pages_skipped.append(info.to_dict())
             return False
 
         # Step 4 — build_categories
@@ -253,9 +253,13 @@ class AddLangCategoriesWorker(BaseObjectsJobWorker):
             return False
 
         if len(langs) == 1 and langs[0] == "en":
-            self._fail(info, "get_languages", "No non-English languages found")
+            info.steps["get_languages"] = {
+                "result": None,
+                "msg": "Skipped — No non-English languages found",
+            }
+            info.status = "skipped"
             return False
-
+            
         info.lang_codes = langs
         info.steps["get_languages"] = {"result": True, "msg": f"Found {len(langs)} language(s): {', '.join(langs)}"}
         return True

--- a/src/main_app/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/worker.py
+++ b/src/main_app/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/worker.py
@@ -187,9 +187,12 @@ class AddLangCategoriesWorker(BaseObjectsJobWorker):
 
         # Step 3 — get_languages
         if not self._step_get_languages(info):
-            self.result.pages_skipped.append(info.to_dict())
+            if info.status == "skipped":
+                self.result.pages_skipped.append(info.to_dict())
+            else:
+                self.result.pages_failed.append(info.to_dict())
             return False
-
+            
         # Step 4 — build_categories
         if not self._step_build_categories(info):
             self.result.pages_skipped.append(info.to_dict())

--- a/tests/unit/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/test_worker.py
+++ b/tests/unit/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/test_worker.py
@@ -224,8 +224,8 @@ class TestStepGetLanguages:
         result = mock_lang_worker._step_get_languages(info)
 
         assert result is False
-        assert info.status == "failed"
-        assert info.error == "No non-English languages found"
+        assert info.status == "skipped"
+        assert info.msg == "Skipped — No non-English languages found"
 
     def test_success_on_english_plus_other(self, mock_lang_worker, mock_lang_categories_services):
         """English alongside other languages should still succeed."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pages with no available non-English languages are now correctly marked as skipped instead of failed.
  * This prevents unnecessary failure reporting for pages that do not require language category processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->