### PR TITLE
Fix test errors and use render_step in add_lang_categories_to_owid_pages details template

### DIFF
--- a/src/templates/jobs_templates/admin_templates/add_lang_categories_to_owid_pages/details.html
+++ b/src/templates/jobs_templates/admin_templates/add_lang_categories_to_owid_pages/details.html
@@ -45,6 +45,12 @@
                         <th>SVG File</th>
                         <th>Languages</th>
                         <th>Categories Added</th>
+                        <th>Load Text</th>
+                        <th>Extract SVG</th>
+                        <th>Get Langs</th>
+                        <th>Build Cats</th>
+                        <th>Check Exist</th>
+                        <th>Save Page</th>
                         <th>Status</th>
                     </tr>
                 </thead>
@@ -82,6 +88,13 @@
                             -
                             {% endif %}
                         </td>
+                        {% set step_keys = [ 'load_page_text', 'extract_file_name', 'get_languages', 'build_categories', 'check_existing', 'save_page' ] %}
+                        {% for step_key in step_keys %}
+                        <td>
+                            {% set step = item.steps.get(step_key) if item.steps else None %}
+                            {{ render_step(step) }}
+                        </td>
+                        {% endfor %}
                         <td>
                             {% if item.status == 'completed' %}
                             <span class="badge bg-success">Updated</span>

--- a/tests/integration/admin/routes/test_add_lang_categories_details_template.py
+++ b/tests/integration/admin/routes/test_add_lang_categories_details_template.py
@@ -1,0 +1,79 @@
+"""
+Integration tests for the add_lang_categories_to_owid_pages job detail template.
+
+Tests cover:
+src/templates/jobs_templates/admin_templates/add_lang_categories_to_owid_pages/details.html
+"""
+
+from __future__ import annotations
+
+import json
+from html import unescape
+
+from src.main_app.db.services import jobs_service as _sqlalchemy_jobs_service
+
+
+def _create_job_with_result(result_data: dict, tmp_path, job_type: str = "add_lang_categories_to_owid_pages"):
+    """Helper to persist a job and a JSON result file, returning the job."""
+    job = _sqlalchemy_jobs_service.create_job(job_type, "admin")
+    result_file = tmp_path / "result.json"
+    result_file.write_text(json.dumps(result_data))
+    _sqlalchemy_jobs_service.update_job_status(job.id, "completed", str(result_file), job_type=job_type)
+    return job
+
+
+def _minimal_result_data(pages_success=None, pages_skipped=None, pages_failed=None):
+    """Return a minimal result_data dict for the add_lang_categories_to_owid_pages template."""
+    return {
+        "summary": {
+            "processed": 1,
+            "total": 1,
+            "success": len(pages_success or []),
+            "skipped": len(pages_skipped or []),
+            "failed": len(pages_failed or []),
+            "no_file": 0,
+        },
+        "pages_success": pages_success or [],
+        "pages_skipped": pages_skipped or [],
+        "pages_failed": pages_failed or [],
+    }
+
+
+class TestAddLangCategoriesDetailsTemplate:
+    def test_step_columns_rendered(self, admin_jobs_client, tmp_path):
+        """All step columns (Load Text, Extract SVG, Get Langs, Build Cats, Check Exist, Save Page) are rendered."""
+        result_data = _minimal_result_data(
+            pages_success=[
+                {
+                    "page_title": "OWID/test-page",
+                    "svg_file": "test-file.svg",
+                    "lang_codes": ["en", "fr"],
+                    "categories_added": ["[[Category:English-language SVG]]", "[[Category:French-language SVG]]"],
+                    "status": "completed",
+                    "steps": {
+                        "load_page_text": {"result": True, "msg": "Loaded page text"},
+                        "extract_file_name": {"result": True, "msg": "SVG file: test-file.svg"},
+                        "get_languages": {"result": True, "msg": "Found 2 languages"},
+                        "build_categories": {"result": True, "msg": "Built candidate category names"},
+                        "check_existing": {"result": True, "msg": "New category lines to add"},
+                        "save_page": {"result": True, "msg": "Saved page"},
+                    },
+                }
+            ]
+        )
+        job = _create_job_with_result(result_data, tmp_path)
+
+        response = admin_jobs_client.get(f"/adminpanel/jobs/add_lang_categories_to_owid_pages/{job.id}")
+        assert response.status_code == 200
+        page = unescape(response.get_data(as_text=True))
+
+        # Verify headers exist
+        assert "Load Text" in page
+        assert "Extract SVG" in page
+        assert "Get Langs" in page
+        assert "Build Cats" in page
+        assert "Check Exist" in page
+        assert "Save Page" in page
+
+        # Verify rendered status using render_step (contains check-lg or diff etc)
+        assert "bi-check-lg" in page or "bg-success" in page

--- a/tests/unit/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/test_worker.py
+++ b/tests/unit/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/test_worker.py
@@ -225,7 +225,7 @@ class TestStepGetLanguages:
 
         assert result is False
         assert info.status == "skipped"
-        assert info.msg == "Skipped — No non-English languages found"
+        assert info.steps["get_languages"]["msg"] == "Skipped — No non-English languages found"
 
     def test_success_on_english_plus_other(self, mock_lang_worker, mock_lang_categories_services):
         """English alongside other languages should still succeed."""


### PR DESCRIPTION
This change fixes the failing test error in `tests/unit/jobs_workers/admin_jobs_workers/add_lang_categories_to_owid_pages/test_worker.py` and updates the job details template at `src/templates/jobs_templates/admin_templates/add_lang_categories_to_owid_pages/details.html` to integrate the `render_step` macro. It also includes a new integration test ensuring that the new step columns render perfectly and correctly in the template. All tests pass successfully.

---
*PR created automatically by Jules for task [8448068519317124691](https://jules.google.com/task/8448068519317124691) started by @MrIbrahem*