### PR TITLE
Fix all failing integration and unit tests

### DIFF
--- a/tests/integration/admin/routes/test_add_lang_categories_details_template.py
+++ b/tests/integration/admin/routes/test_add_lang_categories_details_template.py
@@ -10,15 +10,15 @@ from __future__ import annotations
 import json
 from html import unescape
 
-from src.main_app.db.services import jobs_service as _sqlalchemy_jobs_service
+from src.main_app.db.services import JobsService, jobs_service as _sqlalchemy_jobs_service
 
 
 def _create_job_with_result(result_data: dict, tmp_path, job_type: str = "add_lang_categories_to_owid_pages"):
     """Helper to persist a job and a JSON result file, returning the job."""
-    job = _sqlalchemy_jobs_service.create_job(job_type, "admin")
+    job = JobsService().create_job(job_type, "admin")
     result_file = tmp_path / "result.json"
     result_file.write_text(json.dumps(result_data))
-    _sqlalchemy_jobs_service.update_job_status(job.id, "completed", str(result_file), job_type=job_type)
+    JobsService().update_job_status(job.id, "completed", str(result_file), job_type=job_type)
     return job
 
 

--- a/tests/integration/admin/routes/test_admin_templates_routes.py
+++ b/tests/integration/admin/routes/test_admin_templates_routes.py
@@ -9,23 +9,26 @@ import pytest
 
 from src.main_app.db.models import TemplateRecord
 from src.main_app.db.services import delete_service
-from src.main_app.db.services import template_service as _sqlalchemy_template_service
+from src.main_app.db.services import TemplateService
 
 
 class _TemplatesStore:
     """Adapter bridging old TemplatesDB API to SQLAlchemy template_service functions."""
 
+    def __init__(self):
+        self.service = TemplateService()
+
     def list(self, limit=None):
-        return _sqlalchemy_template_service.list_templates(limit)
+        return self.service.list_templates(limit)
 
     def add_data(self, data):
-        return _sqlalchemy_template_service.add_template_data(data)
+        return self.service.add_template_data(data)
 
     def update_data(self, template_id, data):
-        return _sqlalchemy_template_service.update_template_data(template_id, data)
+        return self.service.update_template_data(template_id, data)
 
     def delete(self, record_id: int):
-        return delete_service.delete_record_by_pk(TemplateRecord, record_id)
+        return self.service.delete(record_id)
 
 
 @pytest.fixture

--- a/tests/integration/admin/routes/test_create_owid_pages_details_template.py
+++ b/tests/integration/admin/routes/test_create_owid_pages_details_template.py
@@ -15,15 +15,15 @@ from __future__ import annotations
 import json
 from html import unescape
 
-from src.main_app.db.services import jobs_service as _sqlalchemy_jobs_service
+from src.main_app.db.services import JobsService, jobs_service as _sqlalchemy_jobs_service
 
 
 def _create_job_with_result(result_data: dict, tmp_path, job_type: str = "create_owid_pages"):
     """Helper to persist a job and a JSON result file, returning the job."""
-    job = _sqlalchemy_jobs_service.create_job(job_type, "admin")
+    job = JobsService().create_job(job_type, "admin")
     result_file = tmp_path / "result.json"
     result_file.write_text(json.dumps(result_data))
-    _sqlalchemy_jobs_service.update_job_status(job.id, "completed", str(result_file), job_type=job_type)
+    JobsService().update_job_status(job.id, "completed", str(result_file), job_type=job_type)
     return job
 
 

--- a/tests/integration/admin/routes/test_owid_charts_integration.py
+++ b/tests/integration/admin/routes/test_owid_charts_integration.py
@@ -74,12 +74,12 @@ def owid_charts_admin_client(monkeypatch: pytest.MonkeyPatch, mock_service):
     _patch_owid_charts_instance(flask_app, mock_service)
 
     monkeypatch.setattr(
-        "src.main_app.admin.routes.owid_charts.OwidChartsService.list_owid_charts_templates",
+        "src.main_app.admin.routes.owid_charts.ViewsService.list_owid_charts_templates",
         MagicMock(return_value=[]),
     )
     monkeypatch.setattr(
         "src.main_app.admin.routes.owid_charts.OwidChartsService.delete",
-        mock_service.delete_chart,
+        mock_service.delete,
     )
 
     yield flask_app.test_client()
@@ -93,6 +93,7 @@ def mock_service():
     mocks.add_chart = MagicMock()
     mocks.update_chart_data = MagicMock()
     mocks.delete_chart = MagicMock()
+    mocks.delete = mocks.delete_chart
     mocks.get_chart_by_id = MagicMock()
     return mocks
 

--- a/tests/integration/admin/routes/test_update_owid_charts_details_template.py
+++ b/tests/integration/admin/routes/test_update_owid_charts_details_template.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 from html import unescape
 
-from src.main_app.db.services import jobs_service as _sqlalchemy_jobs_service
+from src.main_app.db.services import JobsService, jobs_service as _sqlalchemy_jobs_service
 
 _JOB_TYPE = "update_owid_charts"
 
@@ -59,10 +59,10 @@ def _result_data(updated=None, failed=None, skipped=None) -> dict:
 
 
 def _create_job_with_result(result_data: dict, tmp_path):
-    job = _sqlalchemy_jobs_service.create_job(_JOB_TYPE, "admin")
+    job = JobsService().create_job(_JOB_TYPE, "admin")
     result_file = tmp_path / "result.json"
     result_file.write_text(json.dumps(result_data))
-    _sqlalchemy_jobs_service.update_job_status(job.id, "completed", str(result_file), job_type=_JOB_TYPE)
+    JobsService().update_job_status(job.id, "completed", str(result_file), job_type=_JOB_TYPE)
     return job
 
 

--- a/tests/unit/public/test_public_jobs.py
+++ b/tests/unit/public/test_public_jobs.py
@@ -169,7 +169,7 @@ class TestCancelJob:
     def test_no_permission(self, monkeypatch: pytest.MonkeyPatch, mock_user: MagicMock, mock_job: MagicMock) -> None:
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: False)
 
         result = cancel_job_handler(1, "test_job")
@@ -182,7 +182,7 @@ class TestCancelJob:
     ) -> None:
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda jid, jt, j: True)
 
@@ -194,7 +194,7 @@ class TestCancelJob:
     def test_cancel_fails(self, monkeypatch: pytest.MonkeyPatch, mock_user: MagicMock, mock_job: MagicMock) -> None:
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda jid, jt, j: False)
 
@@ -226,7 +226,7 @@ class TestDeleteJob:
     ) -> None:
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda jid, jt, j: False)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.delete_job", lambda self, jid, jt: True)
@@ -242,7 +242,7 @@ class TestDeleteJob:
         """When cancel_job_worker returns True, the job is still deleted."""
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda jid, jt, j: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.delete_job", lambda self, jid, jt: True)
@@ -255,7 +255,7 @@ class TestDeleteJob:
     def test_delete_failure(self, monkeypatch: pytest.MonkeyPatch, mock_user: MagicMock, mock_job: MagicMock) -> None:
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda jid, jt, j: False)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.delete_job", lambda self, jid, jt: False)
@@ -270,7 +270,7 @@ class TestDeleteJob:
     ) -> None:
         mocks = self._setup_mocks(monkeypatch)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda j, u: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda jid, jt, j: False)
         monkeypatch.setattr(
@@ -379,7 +379,7 @@ class TestJobsList:
     def test_normal_listing(self, monkeypatch: pytest.MonkeyPatch, mock_template_data: MagicMock) -> None:
         mocks = self._setup_mocks(monkeypatch)
         mock_jobs = [MagicMock(id=1), MagicMock(id=2)]
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.list_jobs", lambda limit, job_type: mock_jobs)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.list_jobs", lambda *args, **kwargs: mock_jobs)
 
         result = jobs_list_handler("test_job", mock_template_data)
 
@@ -396,7 +396,7 @@ class TestJobsList:
 
     def test_listing_with_0_jobs(self, monkeypatch: pytest.MonkeyPatch, mock_template_data: MagicMock) -> None:
         mocks = self._setup_mocks(monkeypatch)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.list_jobs", lambda limit, job_type: [])
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.list_jobs", lambda *args, **kwargs: [])
 
         result = jobs_list_handler("test_job", mock_template_data)
 
@@ -444,7 +444,7 @@ class TestJobDetail:
         self, monkeypatch: pytest.MonkeyPatch, mock_job: MagicMock, mock_template_data: MagicMock
     ) -> None:
         self._setup_mocks(monkeypatch)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_job_result", lambda rf: None)
 
         result = job_detail_handler(1, "test_job", mock_template_data, "public_jobs")
@@ -467,7 +467,7 @@ class TestJobDetail:
         mock_template_data: MagicMock,
     ) -> None:
         self._setup_mocks(monkeypatch)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job_with_result)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job_with_result)
         monkeypatch.setattr(
             "src.main_app.public.jobs_routes_utils.load_job_result",
             lambda rf: {"key": "value"},
@@ -490,7 +490,7 @@ class TestJobDetail:
         self, monkeypatch: pytest.MonkeyPatch, mock_job: MagicMock, mock_template_data: MagicMock
     ) -> None:
         self._setup_mocks(monkeypatch)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_job_result", lambda rf: None)
 
         result = job_detail_handler(1, "test_job", mock_template_data, "public_jobs", expand_all=True)
@@ -535,16 +535,16 @@ class TestJobsPublicRoutesRoutes:
         Individual tests can override specific mocks for their scenario.
         """
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_user", lambda: mock_user)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda jid, jt: mock_job)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.get_job", lambda *args, **kwargs: mock_job)
         monkeypatch.setattr(
             "src.main_app.public.jobs_routes_utils.JobsService.list_jobs",
-            lambda limit, job_type: [mock_job],
+            lambda *args, **kwargs: [mock_job],
         )
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.can_manage_job", lambda job, user: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_auth_payload", lambda u: {"token": "abc"})
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.cancel_job_worker", lambda *a: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.start_job", lambda au, jt, args: 42)
-        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.delete", lambda jid, jt: True)
+        monkeypatch.setattr("src.main_app.public.jobs_routes_utils.JobsService.delete", lambda *args, **kwargs: True)
         monkeypatch.setattr("src.main_app.public.jobs_routes_utils.load_job_result", lambda rf: {"result": "ok"})
 
         monkeypatch.setattr("src.main_app.public.auth.utils.load_user", lambda: mock_user)


### PR DESCRIPTION
This PR resolves failing integration and unit tests in the repository caused by service-class refactorings. Specifically, it instantiates `JobsService`, `TemplateService`, and `ViewsService` where they were previously called/mocked as module-level functions or on uninstantiated classes, and standardizes monkeypatch mock lambdas to safely accept `*args, **kwargs`.

---
*PR created automatically by Jules for task [8910160068835120499](https://jules.google.com/task/8910160068835120499) started by @MrIbrahem*