### PR TITLE
Refactor database service classes to inherit from a shared base DbService

### DIFF
--- a/src/main_app/db/services/__init__.py
+++ b/src/main_app/db/services/__init__.py
@@ -1,4 +1,5 @@
 from .admin_service import AdminService
+from .base_service import DbService
 from .delete_service import delete_record_by_pk
 from .jobs_service import JobsService
 from .owid_charts_service import OwidChartsService
@@ -11,6 +12,7 @@ from .views_service import ViewsService
 
 __all__ = [
     "AdminService",
+    "DbService",
     "JobsService",
     "OwidChartsService",
     "OwidSlugRedirectsService",

--- a/src/main_app/db/services/admin_service.py
+++ b/src/main_app/db/services/admin_service.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 from ...extensions import db
 from ..exceptions import DuplicateUserError, UserNotFoundError
 from ..models import AdminUserRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard_rollback
 
 logger = logging.getLogger(__name__)
@@ -95,9 +95,9 @@ def _set_coordinator_active(coordinator_id: int, is_active: bool) -> AdminUserRe
     return record
 
 
-class AdminService:
+class AdminService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(AdminUserRecord)
 
     def is_active_coordinator(self, username: str) -> bool:
         return _is_active_coordinator(username)
@@ -113,9 +113,6 @@ class AdminService:
 
     def set_coordinator_active(self, coordinator_id: int, is_active: bool) -> AdminUserRecord | None:
         return _set_coordinator_active(coordinator_id, is_active)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(AdminUserRecord, record_id)
 
 
 __all__ = [

--- a/src/main_app/db/services/base_service.py
+++ b/src/main_app/db/services/base_service.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ...extensions import db
+from .delete_service import delete_record_by_pk
+
+logger = logging.getLogger(__name__)
+
+
+class DbService:
+    def __init__(self, model: type[db.Model]) -> None:
+        self.model = model
+
+    def list_records(self) -> list[Any]:
+        try:
+            return db.session.query(self.model).all()
+        except Exception as exc:
+            logger.error("Error getting records: %s", str(exc))
+            return []
+
+    def get_record_by_id(self, record_id: int) -> Any | None:
+        try:
+            return db.session.get(self.model, record_id)
+        except Exception as exc:
+            logger.error("Error getting record: %s", str(exc))
+            return None
+
+    def add_record(self, data: dict[str, Any]) -> Any | None:
+        try:
+            temp_data = {
+                key: value for key, value in data.items() if value is not None and hasattr(self.model, key)
+            }
+            record = self.model(**temp_data)
+            db.session.add(record)
+            db.session.commit()
+            db.session.refresh(record)
+            return record
+        except Exception as exc:
+            db.session.rollback()
+            logger.error("Error adding record: %s", str(exc))
+            return None
+
+    def add_recoed(self, data: dict[str, Any]) -> Any | None:
+        """Alias for add_record to support potential typos or user compatibility."""
+        return self.add_record(data)
+
+    def update_data(self, record_id: int, data: dict[str, Any]) -> Any | None:
+        try:
+            record = db.session.get(self.model, record_id)
+            if not record:
+                return None
+            for key, value in data.items():
+                if value is not None and hasattr(self.model, key):
+                    setattr(record, key, value)
+            db.session.commit()
+            db.session.refresh(record)
+            return record
+        except Exception as exc:
+            db.session.rollback()
+            logger.error("Error updating record: %s", str(exc))
+            return None
+
+    def delete(self, record_id: int) -> bool:
+        return delete_record_by_pk(self.model, record_id)
+
+
+__all__ = [
+    "DbService",
+]

--- a/src/main_app/db/services/jobs_service.py
+++ b/src/main_app/db/services/jobs_service.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from ...extensions import db
 from ..exceptions import DuplicateJobError
 from ..models import JobRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard, db_guard_rollback, retry_on_db_disconnect
 
 logger = logging.getLogger(__name__)
@@ -325,9 +325,9 @@ def _delete_job_by_id_and_type(job_id: int, job_type: str) -> bool:
         return False
 
 
-class JobsService:
+class JobsService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(JobRecord)
 
     def is_job_cancelled(self, job_id: int, job_type: str) -> bool:
         return _is_job_cancelled(job_id, job_type)
@@ -381,9 +381,6 @@ class JobsService:
 
     def cancel_job_db(self, job_id: int, job_type: str | None = None) -> bool:
         return _cancel_job_db(job_id, job_type)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(JobRecord, record_id)
 
     def delete_job_by_id_and_type(self, job_id: int, job_type: str) -> bool:
         return _delete_job_by_id_and_type(job_id, job_type)

--- a/src/main_app/db/services/owid_charts_service.py
+++ b/src/main_app/db/services/owid_charts_service.py
@@ -7,7 +7,7 @@ from sqlalchemy import func
 
 from ...extensions import db
 from ..models import OwidChartRecord, TemplateRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard_rollback, retry_on_db_disconnect
 
 logger = logging.getLogger(__name__)
@@ -155,9 +155,9 @@ def _update_chart_data_with_retry(
     return _update_chart_data(chart_id, chart_data)
 
 
-class OwidChartsService:
+class OwidChartsService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(OwidChartRecord)
 
     def list_charts(self, limit: int | None = None) -> list[OwidChartRecord]:
         return _list_charts(limit)
@@ -193,9 +193,6 @@ class OwidChartsService:
         chart_data: dict[str, Any],
     ) -> OwidChartRecord | None:
         return _update_chart_data_with_retry(chart_id, chart_data)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(OwidChartRecord, record_id)
 
 
 __all__ = [

--- a/src/main_app/db/services/owid_slug_redirects_service.py
+++ b/src/main_app/db/services/owid_slug_redirects_service.py
@@ -7,7 +7,7 @@ from sqlalchemy import desc
 
 from ...extensions import db
 from ..models.owid_slug_redirects import OwidSlugRedirectRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard, db_guard_rollback
 
 logger = logging.getLogger(__name__)
@@ -111,9 +111,9 @@ def _bulk_delete_slug_redirects(redirect_ids: list[int]) -> None:
         db.session.commit()
 
 
-class OwidSlugRedirectsService:
+class OwidSlugRedirectsService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(OwidSlugRedirectRecord)
 
     def list_slug_redirects(self, limit: int | None = None, offset: int | None = None) -> list[OwidSlugRedirectRecord]:
         return _list_slug_redirects(limit, offset)
@@ -135,9 +135,6 @@ class OwidSlugRedirectsService:
 
     def bulk_delete_slug_redirects(self, redirect_ids: list[int]) -> None:
         return _bulk_delete_slug_redirects(redirect_ids)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(OwidSlugRedirectRecord, record_id)
 
 
 __all__ = [

--- a/src/main_app/db/services/settings_service.py
+++ b/src/main_app/db/services/settings_service.py
@@ -11,7 +11,7 @@ from sqlalchemy.exc import IntegrityError
 
 from ...extensions import db
 from ..models import SettingRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard
 
 logger = logging.getLogger(__name__)
@@ -115,9 +115,9 @@ def _create_setting(
         return False
 
 
-class SettingsService:
+class SettingsService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(SettingRecord)
 
     def list_settings(self) -> list[SettingRecord]:
         try:
@@ -188,13 +188,10 @@ class SettingsService:
     ) -> bool:
         return _create_setting(key, title, value_type, value)
 
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(SettingRecord, record_id)
-
     def delete_setting_by_key(self, key: str) -> bool:
         setting = SettingRecord.query.filter_by(key=key).first()
         if setting:
-            return delete_record_by_pk(SettingRecord, setting.id)
+            return self.delete(setting.id)
         return False
 
 

--- a/src/main_app/db/services/template_service.py
+++ b/src/main_app/db/services/template_service.py
@@ -9,7 +9,7 @@ from ...extensions import db
 from ..exceptions import DuplicateRecordError
 from ..models.templates import TemplateRecord
 from ..templates_utils import ensure_template_data
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard
 
 logger = logging.getLogger(__name__)
@@ -118,9 +118,9 @@ def _update_template_data(
     return template
 
 
-class TemplateService:
+class TemplateService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(TemplateRecord)
 
     def list_templates(self, limit: int | None = None) -> list[TemplateRecord]:
         try:
@@ -155,9 +155,6 @@ class TemplateService:
         template_data: dict[str, str],
     ) -> TemplateRecord | None:
         return _update_template_data(template_id, template_data)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(TemplateRecord, record_id)
 
 
 __all__ = [

--- a/src/main_app/db/services/user_token_service.py
+++ b/src/main_app/db/services/user_token_service.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import joinedload
 from ...extensions import db
 from ...shared.core.crypto import encrypt_value
 from ..models import UserTokenRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 from .utils import db_guard_rollback
 
 logger = logging.getLogger(__name__)
@@ -118,9 +118,9 @@ def _upsert_user_token(
     return orm_obj
 
 
-class UserTokenService:
+class UserTokenService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(UserTokenRecord)
 
     def get_authenticated_user_token(self, user_id: int) -> None | UserTokenRecord:
         return _get_authenticated_user_token(user_id)
@@ -141,9 +141,6 @@ class UserTokenService:
         access_secret: str,
     ) -> UserTokenRecord:
         return _upsert_user_token(user_id, access_key, access_secret)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(UserTokenRecord, record_id)
 
 
 __all__ = [

--- a/src/main_app/db/services/users_service.py
+++ b/src/main_app/db/services/users_service.py
@@ -11,7 +11,7 @@ import logging
 from ...extensions import db
 from ..exceptions import UserNotFoundError
 from ..models import UserRecord
-from .delete_service import delete_record_by_pk
+from .base_service import DbService
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +92,9 @@ def _toggle_can_run_bg_jobs(user_id: int, value: bool) -> UserRecord:
 # ── DELETE ───────────────────────────────────────────────
 
 
-class UsersService:
+class UsersService(DbService):
     def __init__(self) -> None:
-        pass
+        super().__init__(UserRecord)
 
     def list_users(self) -> list[UserRecord]:
         return _list_users()
@@ -113,9 +113,6 @@ class UsersService:
 
     def toggle_can_run_bg_jobs(self, user_id: int, value: bool) -> UserRecord:
         return _toggle_can_run_bg_jobs(user_id, value)
-
-    def delete(self, record_id: int) -> bool:
-        return delete_record_by_pk(UserRecord, record_id)
 
 
 __all__ = [


### PR DESCRIPTION
This PR introduces a reusable `DbService` base database service class that encapsulates common operations like `list_records`, `get_record_by_id`, `add_record` (and `add_recoed`), `update_data`, and `delete`. Eight of the core database service classes are updated to inherit from `DbService` to completely eliminate duplicated boilerplate code (specifically redundant `delete` methods). All tests pass successfully.

---
*PR created automatically by Jules for task [10138258653006776667](https://jules.google.com/task/10138258653006776667) started by @MrIbrahem*