### PR TITLE
Fix pending background jobs due to thread runner signature mismatch

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-10-27 - [Fixing Silent Background Thread Failures due to Argument Mismatches]
+**Learning:** In multi-threaded applications like Flask background tasks, running tasks in standard daemon threads without catching thread-startup or positional-argument errors can result in tasks permanently hanging in a "Pending" state without any logs or progress indicators. Always ensure the thread's target function signature perfectly matches the positional and keyword arguments passed via `threading.Thread(args=...)`.
+**Action:** Always check python's unhandled thread exception warnings in test suites and explicitly align argument lists in `threading.Thread` calls with target function signatures, including defaults for optional arguments like `form_data`.

--- a/src/main_app/jobs_workers/jobs_worker.py
+++ b/src/main_app/jobs_workers/jobs_worker.py
@@ -69,9 +69,10 @@ def _runner(
     target_func: Any,
     flask_app: Flask,
     args: dict[str, Any] | None = None,
+    form_data: dict[str, Any] | None = None,
 ) -> None:
     """
-    args=(job.id, user, cancel_event, target_func, flask_app, args),
+    args=(job.id, user, cancel_event, target_func, flask_app, args, form_data),
     """
     with flask_app.app_context():
         try:
@@ -80,6 +81,7 @@ def _runner(
                 user=user,
                 cancel_event=cancel_event,
                 args=args,
+                form_data=form_data,
             )
         finally:
             _pop_cancel_event(job_id)

--- a/tests/unit/jobs_workers/test_jobs_worker.py
+++ b/tests/unit/jobs_workers/test_jobs_worker.py
@@ -55,6 +55,7 @@ def test_runner():
         user=user,
         cancel_event=cancel_event,
         args=args,
+        form_data=None,
     )
     assert _get_jobs_cancel_event(job_id) is None
 

--- a/tests/unit/jobs_workers/test_jobs_worker1.py
+++ b/tests/unit/jobs_workers/test_jobs_worker1.py
@@ -142,7 +142,7 @@ def test_runner_calls_target_and_cleans_up():
         args=None,
     )
 
-    mock_target.assert_called_once_with(job_id=job_id, user=user, cancel_event=event, args=None)
+    mock_target.assert_called_once_with(job_id=job_id, user=user, cancel_event=event, args=None, form_data=None)
     flask_app.app_context.assert_called_once()
     # After runner finishes, event should be popped from CANCEL_EVENTS
     assert jobs_worker._get_jobs_cancel_event(job_id) is None
@@ -223,7 +223,7 @@ def test_runner_passes_args_to_target():
         flask_app=flask_app,
         args=args,
     )
-    mock_target.assert_called_once_with(job_id=job_id, user=user, cancel_event=event, args=args)
+    mock_target.assert_called_once_with(job_id=job_id, user=user, cancel_event=event, args=args, form_data=None)
 
 
 def test_runner_passes_none_args_by_default():
@@ -245,7 +245,7 @@ def test_runner_passes_none_args_by_default():
         target_func=mock_target,
         flask_app=flask_app,
     )
-    mock_target.assert_called_once_with(job_id=job_id, user=user, cancel_event=event, args=None)
+    mock_target.assert_called_once_with(job_id=job_id, user=user, cancel_event=event, args=None, form_data=None)
 
 
 def test_start_job_param(mock_services):

--- a/tests/unit/jobs_workers/test_jobs_worker_logic.py
+++ b/tests/unit/jobs_workers/test_jobs_worker_logic.py
@@ -66,9 +66,32 @@ def test_runner(flask_app):
     cancel_event = threading.Event()
     _register_cancel_event(1, cancel_event)
 
+    _runner(1, {"user": "test"}, cancel_event, target, flask_app, {"a": 1}, {"form_key": "form_val"})
+
+    target.assert_called_once_with(
+        job_id=1,
+        user={"user": "test"},
+        cancel_event=cancel_event,
+        args={"a": 1},
+        form_data={"form_key": "form_val"},
+    )
+    assert _pop_cancel_event(1) is None  # should be popped
+
+
+def test_runner_no_form_data(flask_app):
+    target = MagicMock()
+    cancel_event = threading.Event()
+    _register_cancel_event(1, cancel_event)
+
     _runner(1, {"user": "test"}, cancel_event, target, flask_app, {"a": 1})
 
-    target.assert_called_once_with(job_id=1, user={"user": "test"}, cancel_event=cancel_event, args={"a": 1})
+    target.assert_called_once_with(
+        job_id=1,
+        user={"user": "test"},
+        cancel_event=cancel_event,
+        args={"a": 1},
+        form_data=None,
+    )
     assert _pop_cancel_event(1) is None  # should be popped
 
 


### PR DESCRIPTION
Resolved the issue where background jobs were remaining in a "Pending" state without progressing. The underlying cause was a positional argument mismatch in the background task execution wrapper `_runner` in `src/main_app/jobs_workers/jobs_worker.py`. The `_runner` signature was missing the `form_data` argument, causing a `TypeError` to be raised when `threading.Thread` tried to launch it, crashing the thread silently.

We updated `_runner`'s signature to accept `form_data: dict[str, Any] | None = None` and forward it to the target background worker function. We also updated affected unit tests in `tests/unit/jobs_workers/test_jobs_worker_logic.py`, `tests/unit/jobs_workers/test_jobs_worker.py`, and `tests/unit/jobs_workers/test_jobs_worker1.py`. Finally, we recorded our learnings in `.jules/bolt.md` and verified that the entire test suite passes successfully.

---
*PR created automatically by Jules for task [16771451823513133841](https://jules.google.com/task/16771451823513133841) started by @MrIbrahem*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved background job execution by correctly forwarding optional form data to job tasks.
  - Prevented failures caused by mismatched task arguments, including cases where form data is omitted.
  - Improved reliability of background processing and reduced silent task failures.

- **Tests**
  - Expanded automated coverage for jobs with populated, omitted, and default form data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->