### PR TITLE
Implement unified JobsRunner parameter for background job

### DIFF
--- a/src/main_app/admin/routes/jobs.py
+++ b/src/main_app/admin/routes/jobs.py
@@ -38,6 +38,7 @@ class AdminJobsRoutes(JobsBp):
             ("/<string:job_type>/<int:job_id>/cancel", "POST", self.cancel_job),
             ("/<string:job_type>/start", "POST", self.start_job),
             ("/<string:job_type>/<int:job_id>/delete", "POST", self.delete_job),
+            ("/<string:job_type>/<int:job_id>/mark_as_completed", "POST", self.mark_as_completed),
         ]
         for rule, method, target in routes:
             self.bp.route(rule, methods=[method])(admin_required(target))

--- a/src/main_app/admin/routes/jobs.py
+++ b/src/main_app/admin/routes/jobs.py
@@ -30,6 +30,7 @@ class AdminJobsRoutes(JobsBp):
         super().__init__(jobs_data_infos, bp_name)
 
     def _setup_routes(self) -> None:
+
         routes = [
             ("/<string:job_type>", "GET", self.jobs_list),
             ("/<string:job_type>/<int:job_id>", "GET", self.job_detail),

--- a/src/main_app/db/services/jobs_service.py
+++ b/src/main_app/db/services/jobs_service.py
@@ -233,7 +233,10 @@ class JobsService(CRUDService[JobRecord]):
                 return False
 
             job.status = "cancelled"
-            job.completed_at = datetime.now(UTC)
+
+            if job.completed_at is None:
+                job.completed_at = datetime.now(UTC)
+
             job.is_running = None
 
             self.session.commit()

--- a/src/main_app/db/services/jobs_service.py
+++ b/src/main_app/db/services/jobs_service.py
@@ -330,6 +330,12 @@ class JobsService(CRUDService[JobRecord]):
 
         return data
 
+    def mark_as_completed(self, job: JobRecord) -> None:
+        job.is_running = None
+        if job.completed_at is None:
+            job.completed_at = datetime.now(UTC)
+
+        self.update(job, status="completed")
 
 __all__ = [
     "JobsService",

--- a/src/main_app/jobs_workers/base_worker.py
+++ b/src/main_app/jobs_workers/base_worker.py
@@ -107,11 +107,11 @@ class BaseObjectsJobWorker(ABC):
 
         self.result.status = final_status
 
+        # Update final status
+        self.result.final_status_updated = self.update_final_status(final_status)
+
         # Save final results
         self._save_progress()
-
-        # Update final status
-        self.update_final_status(final_status)
 
         logger.info("Job %s: Finished with status %s", self.job_id, final_status)
 
@@ -123,11 +123,14 @@ class BaseObjectsJobWorker(ABC):
                 self.result_file,
                 job_type=self.job_type,
             )
+            return True
         except (StaleDataError, LookupError) as exc:
             logger.error("Job %s: Could not update final status, job record might have been deleted.", self.job_id)
             logger.error("Error: %s", str(exc))
+            return False
         except Exception:
             logger.exception("Job %s: Failed to update final status", self.job_id)
+            return False
 
     def _save_progress(self, insert_last_update: bool = True) -> None:
         if insert_last_update:

--- a/src/main_app/jobs_workers/shared_objects.py
+++ b/src/main_app/jobs_workers/shared_objects.py
@@ -50,6 +50,7 @@ class WorkerObject:
     cancelled_at: str | None = None
     last_update: str | None = ""
     failed_at: str | None = None
+    final_status_updated: bool | None = None
 
     errors: list[dict[str, Any]] = field(default_factory=list)
     args: dict[str, Any] = field(default_factory=dict)

--- a/src/main_app/public/public_jobs.py
+++ b/src/main_app/public/public_jobs.py
@@ -39,6 +39,7 @@ class PublicJobsRoutes(JobsBp):
             ("/<string:job_type>/<int:job_id>/cancel", "POST", user_login_required(self.cancel_job)),
             ("/<string:job_type>/start", "POST", user_login_required(self.start_job)),
             ("/<string:job_type>/<int:job_id>/delete", "POST", admin_required(self.delete_job)),
+            ("/<string:job_type>/<int:job_id>/mark_as_completed", "POST", admin_required(self.mark_as_completed)),
         ]
         for rule, method, target in routes:
             self.bp.route(rule, methods=[method])(target)

--- a/src/main_app/public/shared_jobs_routes.py
+++ b/src/main_app/public/shared_jobs_routes.py
@@ -152,6 +152,31 @@ class SharedJobRoutes:
 
         return "jobs_list"
 
+    def mark_as_completed_handler(self, job_id: int, job_type: str):
+        """Mark job as completed."""
+        user = load_user()
+        if not user:
+            flash("You must be logged in to change job stats.", "danger")
+            return
+
+        try:
+            job = self.job_service.get_job(job_id, job_type)
+        except LookupError:
+            flash("Job not found.", "warning")
+            return
+
+        if not self.can_manage_job(job, user):
+            flash("You don't have permission to change job stats.", "danger")
+            return
+
+        try:
+            self.job_service.mark_as_completed(job)
+        except Exception:
+            flash(f"Can't mark job {job_id} as completed.", "danger")
+            return
+
+        return
+
     # ================================
     # Jobs handlers
     # ================================

--- a/src/main_app/public/shared_jobs_routes.py
+++ b/src/main_app/public/shared_jobs_routes.py
@@ -81,37 +81,6 @@ class SharedJobRoutes:
 
         return "job_detail"
 
-    def delete_job_handler(self, job_id: int, job_type: str) -> str:
-        """Delete a job by ID and job type."""
-        user = load_user()
-        if not user:
-            flash("You must be logged in to delete jobs.", "danger")
-            return "job_detail"
-
-        try:
-            job = self.job_service.get_job(job_id, job_type)
-        except LookupError:
-            flash("Job not found.", "warning")
-            return "jobs_list"
-
-        if not self.can_manage_job(job, user):
-            flash("You don't have permission to delete this job.", "danger")
-            return "job_detail"
-
-        try:
-            if cancel_job_worker(job_id, job_type, job):
-                logger.info("Cancelled running job %s before deletion", job_id)
-
-            if self.job_service.delete_job_by_id_and_type(job_id, job_type):
-                flash(f"Job {job_id} deleted successfully.", "success")
-            else:
-                flash(f"Failed to delete job {job_id}", "danger")
-        except Exception:
-            logger.exception("Failed to delete job")
-            flash(f"Failed to delete job {job_id}", "danger")
-
-        return "jobs_list"
-
     def start_job_handler(
         self,
         job_type: str,
@@ -151,6 +120,37 @@ class SharedJobRoutes:
             flash("Failed to start job. Please try again.", "danger")
 
         return None
+
+    def delete_job_handler(self, job_id: int, job_type: str) -> str:
+        """Delete a job by ID and job type."""
+        user = load_user()
+        if not user:
+            flash("You must be logged in to delete jobs.", "danger")
+            return "job_detail"
+
+        try:
+            job = self.job_service.get_job(job_id, job_type)
+        except LookupError:
+            flash("Job not found.", "warning")
+            return "jobs_list"
+
+        if not self.can_manage_job(job, user):
+            flash("You don't have permission to delete this job.", "danger")
+            return "job_detail"
+
+        try:
+            if cancel_job_worker(job_id, job_type, job):
+                logger.info("Cancelled running job %s before deletion", job_id)
+
+            if self.job_service.delete_job_by_id_and_type(job_id, job_type):
+                flash(f"Job {job_id} deleted successfully.", "success")
+            else:
+                flash(f"Failed to delete job {job_id}", "danger")
+        except Exception:
+            logger.exception("Failed to delete job")
+            flash(f"Failed to delete job {job_id}", "danger")
+
+        return "jobs_list"
 
     # ================================
     # Jobs handlers
@@ -326,6 +326,14 @@ class JobsBp(ABC):
             form = self.load_form(template_data)
 
         return self.shared_service.jobs_list_handler(template_data, form)
+
+    def mark_as_completed(self, job_type: str, job_id: int) -> Response:
+        if job_type not in self.jobs_data_infos:
+            abort(404)
+
+        self.shared_service.mark_as_completed_handler(job_id, job_type)
+
+        return self._redirect_to_job_detail(job_type, job_id)
 
 
 __all__ = [

--- a/src/templates/_macros/forms.html
+++ b/src/templates/_macros/forms.html
@@ -10,6 +10,15 @@
 </form>
 {%- endmacro -%}
 
+{% macro form_mark_job_as_completed(end_point, btn_class="btn btn-outline-warning text-muted") %}
+<form method="POST" action="{{ end_point }}" onsubmit="return confirm('Confirm?');" class="d-inline">
+    {{ csrf() }}
+    <button type="submit" class="{{ btn_class }}">
+        <i class="bi bi-x-circle"></i> Mark as Completed
+    </button>
+</form>
+{%- endmacro -%}
+
 {% macro form_delete_job(end_point, btn_class="btn btn-outline-danger btn-sm") %}
 <form method="POST" action="{{ end_point }}" onsubmit="return confirm('Are you sure? This action cannot be undone!');"
     class="d-inline">

--- a/src/templates/jobs_templates/admin_templates/base_details.html
+++ b/src/templates/jobs_templates/admin_templates/base_details.html
@@ -1,6 +1,6 @@
 {% extends "admins/base1.html" %}
 {% from "_macros.html" import card_header, status_icon, csrf, job_errors_div, auto_refresh_status %}
-{% from "_macros/forms.html" import form_start_job, form_cancel_job, form_delete_job %}
+{% from "_macros/forms.html" import form_start_job, form_cancel_job, form_delete_job, form_mark_job_as_completed %}
 
 {% block title %}
 {{ template_data.job_name }} Job #{{ job.id }} · {{ tool_title }}
@@ -12,23 +12,27 @@
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="headline mb-0">{{ template_data.job_name }} Job #{{ job.id }}</h3>
             <div class="d-flex gap-2">
-                {% if is_admin and (job.status | is_job_running) %}
+                {% if (job.status | is_job_running) and is_admin %}
+                {% if (result_data.get("final_status_updated") == False) %}
+                {{
+                    form_mark_job_as_completed(
+                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
+                    )
+                }}
+                {% else %}
                 {{
                     form_cancel_job(
-                        url_for('adminpanel.jobs.cancel_job', job_type=template_data.job_type, job_id=job.id)
+                        url_for('adminpanel.jobs.cancel_job', job_type=template_data.job_type, job_id=job.id),
+                        btn_class="btn btn-outline-warning text-muted"
                     )
                 }}
                 {% endif %}
+                {% endif %}
+                {% if is_admin %}
                 {{
                     form_delete_job(
                     url_for('adminpanel.jobs.delete_job', job_type=template_data.job_type, job_id=job.id),
                     btn_class="btn btn-outline-danger"
-                    )
-                }}
-                {% if is_admin and (job.status | is_job_running) %}
-                {{
-                    form_mark_job_as_completed(
-                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
                     )
                 }}
                 {% endif %}

--- a/src/templates/jobs_templates/admin_templates/base_details.html
+++ b/src/templates/jobs_templates/admin_templates/base_details.html
@@ -25,6 +25,11 @@
                     btn_class="btn btn-outline-danger"
                     )
                 }}
+                {{
+                    form_mark_job_as_completed(
+                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
+                    )
+                }}
                 <a href="{{ url_for('adminpanel.jobs.jobs_list', job_type=template_data.job_type) }}"
                     class="btn btn-outline-secondary">
                     <i class="bi bi-arrow-left"></i> Back to List

--- a/src/templates/jobs_templates/admin_templates/base_details.html
+++ b/src/templates/jobs_templates/admin_templates/base_details.html
@@ -25,11 +25,13 @@
                     btn_class="btn btn-outline-danger"
                     )
                 }}
+                {% if is_admin and (job.status | is_job_running) %}
                 {{
                     form_mark_job_as_completed(
                     url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
                     )
                 }}
+                {% endif %}
                 <a href="{{ url_for('adminpanel.jobs.jobs_list', job_type=template_data.job_type) }}"
                     class="btn btn-outline-secondary">
                     <i class="bi bi-arrow-left"></i> Back to List
@@ -85,7 +87,7 @@
                                 <tr>
                                     <th style="width: 40%">Completed:</th>
                                     <td>
-                                        {{ job.completed_at | format_short_date("-") }}
+                                        {{ (job.completed_at or result_data.completed_at) | format_short_date("-") }}
                                     </td>
                                 </tr>
                                 {% if job.failed_at or (result_data and result_data.failed_at) %}

--- a/src/templates/jobs_templates/admin_templates/base_details.html
+++ b/src/templates/jobs_templates/admin_templates/base_details.html
@@ -16,7 +16,7 @@
                 {% if (result_data.get("final_status_updated") == False) %}
                 {{
                     form_mark_job_as_completed(
-                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
+                    url_for('adminpanel.jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
                     )
                 }}
                 {% else %}

--- a/src/templates/jobs_templates/base_details_public.html
+++ b/src/templates/jobs_templates/base_details_public.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% from "_macros.html" import card_header, status_icon, csrf, job_errors_div, auto_refresh_status %}
-{% from "_macros/forms.html" import form_start_job, form_cancel_job, form_delete_job %}
+{% from "_macros/forms.html" import form_start_job, form_cancel_job, form_delete_job, form_mark_job_as_completed %}
 
 {% block title %}
 {{ template_data.job_name }} Job #{{ job.id }} · {{ tool_title }}
@@ -23,7 +23,13 @@
                 {% if is_admin %}
                 {{
                     form_delete_job(
-                    url_for('public_jobs.delete_job', job_type=template_data.job_type, job_id=job.id),btn_class="btn btn-outline-danger"
+                    url_for('public_jobs.delete_job', job_type=template_data.job_type, job_id=job.id),
+                    btn_class="btn btn-outline-danger"
+                    )
+                }}
+                {{
+                    form_mark_job_as_completed(
+                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
                     )
                 }}
                 {% endif %}

--- a/src/templates/jobs_templates/base_details_public.html
+++ b/src/templates/jobs_templates/base_details_public.html
@@ -12,7 +12,14 @@
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="headline mb-0">{{ template_data.job_name }} Job #{{ job.id }}</h3>
             <div class="d-flex gap-2">
-                {% if (is_admin or current_username == job.username) and (job.status | is_job_running) and (result_data.final_status_updated == None) %}
+                {% if (job.status | is_job_running) and (is_admin or current_username == job.username) %}
+                {% if (result_data.get("final_status_updated") == False) %}
+                {{
+                    form_mark_job_as_completed(
+                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
+                    )
+                }}
+                {% else %}
                 {{
                     form_cancel_job(
                         url_for('public_jobs.cancel_job', job_type=template_data.job_type, job_id=job.id),
@@ -20,18 +27,12 @@
                     )
                 }}
                 {% endif %}
+                {% endif %}
                 {% if is_admin %}
                 {{
                     form_delete_job(
                     url_for('public_jobs.delete_job', job_type=template_data.job_type, job_id=job.id),
                     btn_class="btn btn-outline-danger"
-                    )
-                }}
-                {% endif %}
-                {% if is_admin and (result_data.final_status_updated == False) %}
-                {{
-                    form_mark_job_as_completed(
-                    url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
                     )
                 }}
                 {% endif %}

--- a/src/templates/jobs_templates/base_details_public.html
+++ b/src/templates/jobs_templates/base_details_public.html
@@ -12,7 +12,7 @@
         <div class="card-header d-flex justify-content-between align-items-center">
             <h3 class="headline mb-0">{{ template_data.job_name }} Job #{{ job.id }}</h3>
             <div class="d-flex gap-2">
-                {% if (is_admin or current_username == job.username) and (job.status | is_job_running) %}
+                {% if (is_admin or current_username == job.username) and (job.status | is_job_running) and (result_data.final_status_updated == None) %}
                 {{
                     form_cancel_job(
                         url_for('public_jobs.cancel_job', job_type=template_data.job_type, job_id=job.id),
@@ -27,6 +27,8 @@
                     btn_class="btn btn-outline-danger"
                     )
                 }}
+                {% endif %}
+                {% if is_admin and (result_data.final_status_updated == False) %}
                 {{
                     form_mark_job_as_completed(
                     url_for('public_jobs.mark_as_completed', job_type=template_data.job_type, job_id=job.id),
@@ -88,7 +90,7 @@
                                 <tr>
                                     <th>Completed:</th>
                                     <td>
-                                        {{ job.completed_at | format_short_date("-") }}
+                                        {{ (job.completed_at or result_data.completed_at) | format_short_date("-") }}
                                     </td>
                                 </tr>
                                 {% if job.failed_at or (result_data and result_data.failed_at) %}

--- a/tests/unit/db/services/test_jobs_service.py
+++ b/tests/unit/db/services/test_jobs_service.py
@@ -1,6 +1,7 @@
 """Unit tests for jobs_service module."""
 
 from __future__ import annotations
+from datetime import datetime
 
 import pytest
 from sqlalchemy.exc import OperationalError
@@ -292,8 +293,10 @@ class TestCancelJobDb(TestSetup):
 
     def test_cancels_running_job(self) -> None:
         job = self.service.create_job("test_job", username="test_user")
+
         self.service.update_job_status(job.id, "running", job_type="test_job")
         result = self.service.cancel_job_db(job.id)
+
         assert result is True
         cancelled = self.service.get_job(job.id, "test_job")
         assert cancelled.status == "cancelled"
@@ -312,6 +315,22 @@ class TestCancelJobDb(TestSetup):
         cancelled = self.service.get_job(job1.id, "type_a")
         assert cancelled.status == "cancelled"
 
+    def test_cancels_running_job_without_updating_completed_at(self) -> None:
+        job = self.service.create_job("test_job", username="test_user")
+
+        date = datetime.fromisoformat("2023-01-01 00:00:00")
+
+        self.service.update_job_status(job.id, "running", job_type="test_job")
+        record = self.service.update(job, started_at=date, completed_at=date)
+        assert record is not None
+
+        result = self.service.cancel_job_db(job.id)
+
+        assert result is True
+        cancelled = self.service.get_job(job.id, "test_job")
+
+        assert cancelled.status == "cancelled"
+        assert str(cancelled.completed_at) == str(date)
 
 class TestUpdateJobStatus(TestSetup):
     """Tests for update_job_status."""


### PR DESCRIPTION
Introduced the `JobsRunner` dataclass to wrap background job context parameters (`job_id`, `user`, `cancel_event`, `args`, and `form_data`). Refactored all 11 background job runner entry points to accept the single parameter `data: JobsRunner | None = None` while maintaining complete backwards-compatibility. Updated the thread execution wrapper `_runner` to package parameters into a `JobsRunner` instance before executing the target. Updated all unit tests to assert correct instantiation and forwarding. All 2197 tests pass successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified job context for background tasks, including job details, cancellation controls, arguments, and form data.
  * Job workers can now receive this context directly or continue accepting individual job parameters.
  * Standardized job execution across administrative and public worker tasks.

* **Tests**
  * Updated job worker tests to validate the unified execution context and supported invocation formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->