### PR TITLE
Bypass CDN Caching on SVG File Downloads

### DIFF
--- a/src/main_app/api_services/files_service/downloader.py
+++ b/src/main_app/api_services/files_service/downloader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from pathlib import Path
 from urllib.parse import quote
 
@@ -52,7 +53,9 @@ def download_and_save(
     # Use the core download function with shorter timeout
     try:
         normalized_name = title.replace(" ", "_")
-        url = f"{BASE_COMMONS_URL}{quote(normalized_name)}"
+        # Append a cache-buster query parameter to bypass Varnish/CDN caching
+        cache_buster = int(time.time())
+        url = f"{BASE_COMMONS_URL}{quote(normalized_name)}?cb={cache_buster}"
 
         downloader = CommonsSession(session, timeout=30)
         download_result: GetWithRetryData = downloader.get_with_retry_obj(url=url, max_attempts=5)


### PR DESCRIPTION
Addressed the issue where newly uploaded SVG translations were not retrieved by the translation tool until the web service was restarted.

By appending a dynamic cache-buster timestamp query parameter to the download URL in `download_and_save`, we guarantee that Varnish and CDN caching layers are bypassed, retrieving the absolute latest version of the file instantly on every download.

---
*PR created automatically by Jules for task [17452408091030547190](https://jules.google.com/task/17452408091030547190) started by @MrIbrahem*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file downloads by ensuring requests retrieve the latest available content instead of cached responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->