### PR TITLE
⚡ Bolt: Optimize set() recreation bottleneck in explorer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+# Bolt Performance Journal
+
+This journal records critical learnings regarding application performance optimizations, specific bottlenecks, and lessons learned.
+
+## 2026-03-01 - Avoid set() Reconstruction in Comprehensions
+**Learning:** Re-instantiating a `set` from an iterable inside a list comprehension or generator expression creates an O(N*M) performance bottleneck, as the set is re-allocated and populated on every iteration.
+**Action:** Always instantiate the `set` outside the list comprehension/generator and perform lookups against the pre-allocated set to achieve O(N + M) complexity.

--- a/src/main_app/public/main_routes/explorer_routes.py
+++ b/src/main_app/public/main_routes/explorer_routes.py
@@ -87,7 +87,9 @@ class ExplorerRoutes:
         # title = get_temp_title(title_dir)
         title = title_dir
 
-        not_translated = [x for x in downloaded if x not in set(translated)]
+        # Optimize O(N^2) set recreation bottleneck to O(N + M) by instantiating set once outside the loop
+        translated_set = set(translated)
+        not_translated = [x for x in downloaded if x not in translated_set]
 
         return render_template(
             "explorer/explore_files.html",

--- a/src/main_app/public/utils/explorer_utils.py
+++ b/src/main_app/public/utils/explorer_utils.py
@@ -122,7 +122,9 @@ def get_informations(title: str) -> dict:
     languages = get_languages(title, data.get("translations"))
 
     # not_translated = set(downloaded).difference(translated)
-    not_translated = [x for x in downloaded if x not in set(translated)]
+    # Optimize O(N^2) set recreation bottleneck to O(N + M) by instantiating set once outside the loop
+    translated_set = set(translated)
+    not_translated = [x for x in downloaded if x not in translated_set]
     downloaded_set = {f.lower() for f in downloaded}
     not_downloaded = [
         (f"File:{x}" if not x.lower().startswith("file:") else x)


### PR DESCRIPTION
Moved `set(translated)` instantiation outside of list comprehensions in `explorer_routes.py` and `explorer_utils.py` to achieve O(N + M) performance, eliminating O(N * M) overhead. All tests pass successfully.

---
*PR created automatically by Jules for task [13897547739857798690](https://jules.google.com/task/13897547739857798690) started by @MrIbrahem*